### PR TITLE
Implement species categories (fix #15)

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -253,3 +253,25 @@ check_object_name <- function(object) {
   
   invisible(NULL)
 }
+
+#' Check 'species_categories' input
+#' 
+#' @description
+#' This function will error if the provided input doesn't contain exactly 2
+#' columns and isn't a data.frame
+#'
+#' @param species_categories 2-columns `data.frame` giving species categories
+#'   `NULL` by default, with the first column describing the species name, and
+#'   the second column giving their corresponding categories
+#'
+#' @noRd
+check_species_categories <- function(species_categories) {
+  
+  if (
+    !is.null(species_categories) &
+    (!is.data.frame(species_categories) | sum(ncol(species_categories)) != 2)
+  ) {
+    stop("'species_categories' isn't a two-column data.frame", call. = FALSE)
+  }
+  
+}

--- a/R/fb_get_environment.R
+++ b/R/fb_get_environment.R
@@ -55,9 +55,10 @@ fb_get_environment <- function(site_locations, environment_raster) {
   
   ## Extract values ------------------------------------------------------------
   
-  env_values <- terra::extract(x = environment_raster, 
-                               y = terra::vect(site_locations), 
-                               fun = mean, na.rm = TRUE, df = TRUE)
+  env_values <- terra::extract(
+    x = environment_raster, y = terra::vect(site_locations), 
+    fun = mean, na.rm = TRUE
+  )
   
   
   ## Add sites ID --------------------------------------------------------------

--- a/R/fb_get_trait_combination_coverage.R
+++ b/R/fb_get_trait_combination_coverage.R
@@ -76,7 +76,7 @@ fb_get_trait_combination_coverage = function(
   all_combinations = lapply(
     target_combs,
     function(x) {
-      combn(traits, x, simplify = FALSE)
+      utils::combn(traits, x, simplify = FALSE)
     }
   )
   

--- a/R/fb_get_trait_coverage_by_site.R
+++ b/R/fb_get_trait_coverage_by_site.R
@@ -57,7 +57,9 @@ fb_get_trait_coverage_by_site <- function(site_species, species_traits) {
   
   # Count all species (presence/abundance) per site ----
   
-  site_total_abundance <- rowSums(site_species[ , -1], na.rm = TRUE)
+  site_total_abundance <- rowSums(
+    site_species[ , -1, drop = FALSE], na.rm = TRUE
+  )
   
   
   # Count species with traits per site -----

--- a/R/fb_plot_number_species_by_trait.R
+++ b/R/fb_plot_number_species_by_trait.R
@@ -4,6 +4,7 @@
 #' with non-NA trait for each trait ranked in decreasing order.
 #' 
 #' @inheritParams fb_filter_traits_by_species_coverage
+#' @inheritParams fb_plot_species_traits_completeness
 #'
 #' @return a ggplot2 object
 #'
@@ -18,25 +19,104 @@
 #' @importFrom rlang .data
 #' @export
 fb_plot_number_species_by_trait <- function(
-  species_traits, threshold_species_proportion = NULL
+  species_traits, species_categories = NULL, threshold_species_proportion = NULL
 ) {
   
-  # Make dataset long
-  species_traits_long <- tidyr::pivot_longer(
-    species_traits, -"species", names_to = "trait_name",
-    values_to = "trait_value"
+  # Checks
+  check_species_categories(species_categories)
+  
+  species_traits_categories <- list(species_traits)
+  
+  if (!is.null(species_categories)) {
+    
+    species_traits_categories <- merge(
+      species_traits, species_categories, by = colnames(species_categories)[1]
+    )
+    
+    species_traits_categories <- split(
+      species_traits_categories[
+        , -ncol(species_traits_categories), drop = FALSE
+      ],
+      species_traits_categories[, ncol(species_traits_categories)]
+    )
+    
+  }
+  
+  n_species <- nrow(species_traits)
+  
+  number_species_per_trait <- lapply(
+    species_traits_categories,
+    function(x) {
+      trait_coverage <- fb_count_species_by_trait(x)
+      
+      trait_coverage$trait <- factor(
+        trait_coverage$trait, levels = rev(trait_coverage$trait)
+      )
+      
+      trait_coverage[["prop_species"]] <- trait_coverage[["n_species"]]/nrow(x)
+      
+      return(trait_coverage)
+    }
   )
   
-  number_species_per_trait <- fb_count_species_by_trait(species_traits)
+  if (is.null(species_categories)) {
+    
+    number_species_per_trait <- do.call(rbind, number_species_per_trait)
+    
+    category_facet <- NULL
+    
+  } else {
+    
+    number_species_per_trait <- lapply(
+      names(number_species_per_trait),
+      function(x) {
+        
+        single_category <- number_species_per_trait[[x]]
+        
+        single_category[[colnames(species_categories)[2]]] <- x
+        
+        return(single_category)
+      }
+    )
+    
+    number_species_per_trait <- do.call(rbind, number_species_per_trait)
+    
+    category_facet <- ggplot2::facet_wrap(
+      ggplot2::vars(
+        !!rlang::sym(colnames(species_categories)[[2]])), scales = "free"
+    )
+    
+  }
   
-  number_species_per_trait$trait <- factor(
-    number_species_per_trait$trait, levels = rev(number_species_per_trait$trait)
-  )
   
-  number_species_per_trait[["prop_species"]] <- 
-    number_species_per_trait[["n_species"]]/nrow(species_traits)
+  # Clean environment
+  rm(species_traits, species_categories)
   
-  given_plot <- ggplot2::ggplot(
+  # Add threshold line underneath other layers
+  if (!is.null(threshold_species_proportion)) {
+    
+    vline_annotation <- list(
+        ggplot2::geom_vline(
+          xintercept = threshold_species_proportion * n_species,
+          linetype = 2, size = 1.2, color = "darkred"
+        ),
+        ggplot2::annotate(
+          "text", x = threshold_species_proportion * n_species,
+          y = 0.95, hjust = 1.1, color = "darkred",
+          label = paste0(
+            "(n = ", round(threshold_species_proportion * n_species),
+            ")\n(p = ",
+            round(threshold_species_proportion * 100, digits = 1), "%)"
+          )
+        )
+      )
+    
+  } else {
+    vline_annotation <- NULL
+  }
+  
+  # Plot
+  ggplot2::ggplot(
     number_species_per_trait, ggplot2::aes(.data$n_species, .data$trait)
   ) +
     ggplot2::geom_point() +
@@ -51,10 +131,12 @@ fb_plot_number_species_by_trait <- function(
       ),
       hjust = 0.5, vjust = -0.6, size = 3
     ) +
+    category_facet +
+    vline_annotation + 
     ggplot2::scale_x_continuous(
       "Number of Species",
       sec.axis = ggplot2::sec_axis(
-        trans = ~./nrow(species_traits), "Proportion of Species",
+        trans = ~./n_species, "Proportion of Species",
         labels = scales::label_percent()
       ),
       # Add a tiny bit of space so that proportion can be shown
@@ -62,32 +144,4 @@ fb_plot_number_species_by_trait <- function(
     ) +
     ggplot2::labs(y = "Trait Name") +
     ggplot2::theme_bw()
-  
-  
-  # Add threshold line underneath other layers
-  if (!is.null(threshold_species_proportion)) {
-    
-    given_plot$layers <- append(
-      given_plot$layers,
-      list(
-        ggplot2::geom_vline(
-          xintercept = threshold_species_proportion * nrow(species_traits),
-          linetype = 2, size = 1.2, color = "darkred"
-        ),
-        ggplot2::annotate(
-          "text", x = threshold_species_proportion * nrow(species_traits),
-          y = 0.95, hjust = 1.1, color = "darkred",
-          label = paste0(
-            "(n = ", round(threshold_species_proportion * nrow(species_traits)),
-            ")\n(p = ",
-            round(threshold_species_proportion * 100, digits = 1), "%)"
-          )
-        )
-      ),
-      after = 1
-    )
-    
-  }  
-  
-  return(given_plot)
 }

--- a/R/fb_plot_number_species_by_trait.R
+++ b/R/fb_plot_number_species_by_trait.R
@@ -25,22 +25,9 @@ fb_plot_number_species_by_trait <- function(
   # Checks
   check_species_categories(species_categories)
   
-  species_traits_categories <- list(species_traits)
-  
-  if (!is.null(species_categories)) {
-    
-    species_traits_categories <- merge(
-      species_traits, species_categories, by = colnames(species_categories)[1]
-    )
-    
-    species_traits_categories <- split(
-      species_traits_categories[
-        , -ncol(species_traits_categories), drop = FALSE
-      ],
-      species_traits_categories[, ncol(species_traits_categories)]
-    )
-    
-  }
+  species_traits_categories <- split_species_categories(
+    species_traits, species_categories
+  )
   
   n_species <- nrow(species_traits)
   
@@ -59,9 +46,9 @@ fb_plot_number_species_by_trait <- function(
     }
   )
   
+  
+  # Manage conditional faceting
   if (is.null(species_categories)) {
-    
-    number_species_per_trait <- do.call(rbind, number_species_per_trait)
     
     category_facet <- NULL
     
@@ -79,14 +66,14 @@ fb_plot_number_species_by_trait <- function(
       }
     )
     
-    number_species_per_trait <- do.call(rbind, number_species_per_trait)
-    
     category_facet <- ggplot2::facet_wrap(
       ggplot2::vars(
         !!rlang::sym(colnames(species_categories)[[2]])), scales = "free"
     )
     
   }
+  
+  number_species_per_trait <- do.call(rbind, number_species_per_trait)
   
   
   # Clean environment

--- a/R/fb_plot_number_species_by_trait.R
+++ b/R/fb_plot_number_species_by_trait.R
@@ -14,7 +14,7 @@
 #' fb_plot_number_species_by_trait(species_traits)
 #' 
 #' # Add a vertical cutoff line (12.5% of species)
-#' fb_plot_number_species_by_trait(species_traits, 1/8)
+#' fb_plot_number_species_by_trait(species_traits, NULL, 1/8)
 #' 
 #' @importFrom rlang .data
 #' @export

--- a/R/fb_plot_number_traits_by_species.R
+++ b/R/fb_plot_number_traits_by_species.R
@@ -6,6 +6,7 @@
 #' This plot doesn't show which traits are concerned.
 #'
 #' @inheritParams fb_filter_traits_by_species_coverage
+#' @inheritParams fb_plot_species_traits_completeness
 #'
 #' @return a `ggplot2` object
 #' 
@@ -15,36 +16,81 @@
 #' fb_plot_number_traits_by_species(species_traits)
 #' 
 #' # Add a vertical cutoff line (33% of the species)
-#' fb_plot_number_traits_by_species(species_traits, 1/3)
+#' fb_plot_number_traits_by_species(
+#'   species_traits, threshold_species_proportion = 1/3
+#'  )
 #' 
 #' @importFrom rlang .data
 #' @export
 fb_plot_number_traits_by_species <- function(
-  species_traits, threshold_species_proportion = NULL
+  species_traits, species_categories = NULL, threshold_species_proportion = NULL
 ) {
   
-  # Make dataset long
-  species_traits_long <- tidyr::pivot_longer(
-    species_traits, -"species", names_to = "trait_name",
-    values_to = "trait_value"
+  check_species_categories(species_categories)
+  
+  n_species <- nrow(species_traits)
+  
+  # Split trait along list
+  species_traits_categories <- split_species_categories(
+    species_traits, species_categories
   )
   
-  number_trait_per_species <- fb_count_traits_by_species(species_traits)
+  number_trait_per_species <- lapply(
+    species_traits_categories, fb_count_traits_by_species
+  )
   
   # Count number of species per number of trait (XX species has YY traits)
-  number_trait_per_species <- by(
-    number_trait_per_species, number_trait_per_species$n_traits,
-    function(x) c(n = nrow(x))
+  number_trait_per_species <- lapply(
+    number_trait_per_species,
+    function(x) {
+      number_category <- by(x, x$n_traits, function(y) c(n = nrow(y)))
+      
+      number_category <- utils::stack(number_category)
+      number_category$n_traits <- as.numeric(as.character(number_category$ind))
+      
+      # Compute number to show at least 0 or more, etc.
+      number_category[["at_least"]] <- rev(
+        cumsum(rev(number_category$values))
+      )
+      
+      return(number_category)
+    }
   )
-  number_trait_per_species <- utils::stack(number_trait_per_species)
-  number_trait_per_species$n_traits <-
-    as.numeric(as.character(number_trait_per_species$ind))
   
-  # Compute number to show at least 0 or more, etc.
-  number_trait_per_species[["at_least"]] <- rev(
-    cumsum(rev(number_trait_per_species$values))
-  )
+  # Conditional faceting
+  if (is.null(species_categories)) {
+    
+    category_facet <- NULL
+    
+  } else {
+    
+    number_trait_per_species <- lapply(
+      names(number_trait_per_species),
+      function(x) {
+        
+        single_category <- number_trait_per_species[[x]]
+        
+        single_category[[colnames(species_categories)[2]]] <- x
+        
+        return(single_category)
+      }
+    )
+    
+    category_facet <- ggplot2::facet_wrap(
+      ggplot2::vars(
+        !!rlang::sym(colnames(species_categories)[[2]])), scales = "free"
+    )
+  }
   
+  number_trait_per_species <- do.call(rbind, number_trait_per_species)
+  max_n_trait <- max(number_trait_per_species[["n_traits"]])
+  
+  
+  # Clean environment
+  rm(species_traits, species_traits_categories)
+  
+  
+  # Actual plot
   given_plot <- ggplot2::ggplot(
     number_trait_per_species, ggplot2::aes(.data$at_least, .data$n_traits)
   ) +
@@ -57,20 +103,21 @@ fb_plot_number_traits_by_species <- function(
     ggplot2::geom_text(
       ggplot2::aes(
         label = paste0(
-          round((.data$at_least/nrow(species_traits)) * 100, 1), "%"
+          round((.data$at_least/n_species) * 100, 1), "%"
         ),
         x = .data$at_least, y = .data$n_traits
       ), hjust = 0.5, vjust = -0.6, size = 3
     ) +
+    category_facet +
     ggplot2::labs(x = "Number of Species", y = "Number of Traits") +
     ggplot2::scale_x_continuous(
       sec.axis = ggplot2::sec_axis(
-        ~./nrow(species_traits), "Proportion of Species",
+        ~./n_species, "Proportion of Species",
         labels = scales::label_percent()
       )
     ) +
     ggplot2::scale_y_continuous(
-      breaks = seq(0, to = max(number_trait_per_species$n_trait), by = 1),
+      breaks = seq(0, to = max_n_trait, by = 1),
       labels = function(x) ifelse(
         x <= 1, paste0("\u2265", x, " trait"),
         ifelse(x < ncol(species_traits) - 1, paste0("\u2265", x, " traits"),

--- a/R/fb_plot_site_traits_completeness.R
+++ b/R/fb_plot_site_traits_completeness.R
@@ -10,6 +10,7 @@
 #' shows a summary considering traits together.
 #' 
 #' @inheritParams fb_get_all_trait_coverages_by_site
+#' @inheritParams fb_plot_species_traits_completeness
 #'
 #' @return a ggplot2 object
 #'
@@ -19,78 +20,180 @@
 #' @importFrom rlang .data
 #' @export
 fb_plot_site_traits_completeness <- function(
-    site_species, species_traits, all_traits = TRUE
+    site_species, species_traits, species_categories = NULL, all_traits = TRUE
 ) {
   
   # Checks
   check_site_species(site_species)
   check_species_traits(species_traits)
-  
-  all_coverage <- fb_get_all_trait_coverages_by_site(
-    site_species, species_traits, all_traits = all_traits
-  )
-  
-  all_coverage <- tidyr::pivot_longer(
-    all_coverage, -"site", names_to = "coverage_name",
-    values_to = "coverage_value"
-  )
-  
-  site_order <- by(
-    all_coverage, all_coverage$site, function(x) mean(x$coverage_value)
-  )
-  site_order <- utils::stack(site_order)
-  
-  coverage_order <- by(
-    all_coverage, all_coverage$coverage_name, function(x) mean(x$coverage_value)
-  )
-  coverage_order <- utils::stack(coverage_order)
-  
-  # Reorder sites and traits by average coverage
-  all_coverage$site <- factor(
-    all_coverage$site,
-    levels = site_order[["ind"]][
-      order(site_order[["values"]], decreasing = TRUE)
-    ]
-  )
-  
-  all_coverage$coverage_name <- factor(
-    all_coverage$coverage_name,
-    levels = coverage_order[["ind"]][
-      order(coverage_order[["values"]], decreasing = TRUE)
-    ]
-  )
+  check_species_categories(species_categories)
   
   
-  # Get averaging coverage
-  avg_coverage <- by(
-    all_coverage, all_coverage$coverage_name,
-    function(x) mean(x$coverage_value)
-  )
+  # Splitting species by category
+  species_split <- list(single_cat = species_traits[["species"]])
+  category_name <- "single_cat"
   
-  avg_coverage <- utils::stack(avg_coverage)
-  colnames(avg_coverage) <- c("avg_coverage", "coverage_name")
-  
-  avg_coverage[["cov_label"]] <- 
-    with(
-      avg_coverage,
-      paste0(
-        coverage_name, "\n(", round(avg_coverage * 100, 1), "%)"
-      )
+  if (!is.null(species_categories)) {
+    
+    category_name <- colnames(species_categories)[2]
+    
+    species_split <- split(
+      species_categories[, 1], species_categories[, 2]
     )
+    
+  }
   
-  avg_coverage <- avg_coverage[, c("cov_label", "coverage_name")]
-  avg_coverage <- t(utils::unstack(avg_coverage))
+  
+  # Split sites according to species categories
+  site_species_categories <- lapply(
+    species_split,
+    function(x) site_species[, c("site", x), drop = FALSE]
+  )
+  
+  all_coverage <- lapply(
+    site_species_categories,
+    function(x) fb_get_all_trait_coverages_by_site(
+      x, species_traits, all_traits = all_traits
+    )
+  )
+  
+  all_coverage <- lapply(
+    all_coverage,
+    function(single_coverage) {
+      
+      single_coverage <- tidyr::pivot_longer(
+        single_coverage, -"site", names_to = "coverage_name",
+        values_to = "coverage_value"
+      )
+      
+      site_order <- by(
+        single_coverage, single_coverage$site,
+        function(x) mean(x$coverage_value)
+      )
+      site_order <- utils::stack(site_order)
+      
+      coverage_order <- by(
+        single_coverage, single_coverage$coverage_name,
+        function(x) mean(x$coverage_value)
+      )
+      coverage_order <- utils::stack(coverage_order)
+      
+      # Reorder sites and traits by average coverage
+      single_coverage$site <- factor(
+        single_coverage$site,
+        levels = site_order[["ind"]][
+          order(site_order[["values"]], decreasing = TRUE)
+        ]
+      )
+      
+      single_coverage$coverage_name <- factor(
+        single_coverage$coverage_name,
+        levels = coverage_order[["ind"]][
+          order(coverage_order[["values"]], decreasing = TRUE)
+        ]
+      )
+      
+      return(single_coverage)
+    }
+  )
   
   
+  # Get average coverage
+  avg_coverage <- lapply(
+    all_coverage,
+    function(x) {
+      avg_coverage <- by(
+        x, x$coverage_name,
+        function(y) mean(y$coverage_value, na.rm = TRUE)
+      )
+      
+      avg_coverage <- utils::stack(avg_coverage)
+      colnames(avg_coverage) <- c("avg_coverage", "coverage_name")
+      
+      avg_coverage[["cov_label"]] <- 
+        with(
+          avg_coverage,
+          paste0(
+            coverage_name, "\n(", round(avg_coverage * 100, 1), "%)"
+          )
+        )
+      
+      avg_coverage <- avg_coverage[, c("cov_label", "coverage_name")]
+      avg_coverage <- t(utils::unstack(avg_coverage))
+    }
+  )
+  
+  
+  # Add categories back into data.frame
+  all_coverage <- lapply(
+    names(all_coverage),
+    function(x) {
+      
+      given_coverage <- all_coverage[[x]]
+      
+      given_coverage[category_name] <- x
+        
+      return(given_coverage)
+    }
+  )
+  
+  all_coverage <- do.call(rbind, all_coverage)
+  
+  avg_coverage <- lapply(
+    names(avg_coverage),
+    function(x) {
+      
+      given_coverage <- data.frame(
+        coverage_name = colnames(avg_coverage[[x]]),
+        avg_coverage = as.character(avg_coverage[[x]])
+      )
+      
+      given_coverage[category_name] <- x
+      
+      return(given_coverage)
+    }
+  )
+  
+  avg_coverage <- do.call(rbind, avg_coverage)
+  
+  
+  # Manage conditional faceting
+  if (is.null(species_categories)) {
+    
+    category_facet <- NULL
+    
+  } else {
+    
+    category_facet <- ggplot2::facet_wrap(
+      ggplot2::vars(
+        !!rlang::sym(category_name)), scales = "free"
+    )
+    
+  }
+  
+  all_coverage <- merge(
+    all_coverage, avg_coverage, by = c("coverage_name", category_name)
+  )
+  
+  # Clean environment
+  rm(all_traits, avg_coverage, site_species, site_species_categories,
+     species_categories, species_split, species_traits)
+  
+  # Actual Plot
   ggplot2::ggplot(
     all_coverage,
-    ggplot2::aes(.data$coverage_name, .data$site, fill = .data$coverage_value)
+    ggplot2::aes(
+      interaction(.data$avg_coverage, .data[[category_name]], sep = "__"), .data$site,
+      fill = .data$coverage_value
+    )
   ) +
     ggplot2::geom_tile() +
+    category_facet +
     ggplot2::coord_cartesian(expand = FALSE) +
     ggplot2::labs(x = "Trait Name", y = "Sites") +
     ggplot2::scale_x_discrete(
-      labels = avg_coverage, guide = ggplot2::guide_axis(n.dodge = 2)
+      labels = function(x) unlist(strsplit(x, "__.+$")),
+      guide = ggplot2::guide_axis(n.dodge = 2)
     ) +
     ggplot2::scale_fill_viridis_b(
       n.breaks = 10,

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -35,21 +35,12 @@ fb_plot_species_traits_completeness <- function(
   
   
   # Split species by categories (even when there are none)
-  species_traits_categories <- list(species_traits)
+  species_traits_categories <- split_species_categories(
+    species_traits, species_categories
+  )
   species_traits_long_categories <- species_traits_long
   
   if (!is.null(species_categories)) {
-    # Conditional loop to split trait dataset across provided categories
-    
-    species_traits_categories <- merge(
-      species_traits, species_categories, by.x = colnames(species_traits)[1],
-      by.y = colnames(species_categories)[1]
-    )
-    
-    species_traits_categories <- split(
-      species_traits_categories[, -ncol(species_traits_categories)],
-      species_traits_categories[, ncol(species_traits_categories)]
-    )
     
     species_traits_long_categories <- merge(
       species_traits_long, species_categories,

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -10,6 +10,9 @@
 #' shows a summary considering if all other traits are known.
 #'
 #' @inheritParams fb_get_all_trait_coverages_by_site
+#' @param species_categories 2-columns `data.frame` giving species categories
+#'   `NULL` by default, with the first column describing the species name, and
+#'   the second column giving their corresponding categories
 #'
 #' @return a `ggplot2` object
 #'
@@ -19,76 +22,226 @@
 #' 
 #' @export
 fb_plot_species_traits_completeness <- function(
-    species_traits, all_traits = TRUE
+    species_traits, species_categories = NULL, all_traits = TRUE
 ) {
   
-  # Make dataset long
+  # Check 'species_categories' input
+  if (
+    !is.null(species_categories) &
+    (!is.data.frame(species_categories) | sum(ncol(species_categories)) != 2)
+  ) {
+    stop("'species_categories' isn't a two-column data.frame", call. = FALSE)
+  }
+  
+  
+  # Make dataset long to get all trait values by rows
   species_traits_long <- tidyr::pivot_longer(
-      species_traits, -"species", names_to = "trait_name",
+      species_traits, -"species", names_to = "trait",
       values_to = "trait_value", values_transform = as.character
     )
   
-  # Count Number of Species per Trait
-  number_species_per_trait <- fb_count_species_by_trait(species_traits)
   
-  # Get Combination for All Traits
-  number_trait_per_species <- fb_count_traits_by_species(species_traits)
+  # Split species by categories (even when there are none)
+  species_traits_categories <- list(species_traits)
+  species_traits_long_categories <- species_traits_long
   
-  max_traits <- max(number_trait_per_species$n_traits)
+  if (!is.null(species_categories)) {
+    # Conditional loop to split trait dataset across provided categories
+    
+    species_traits_categories <- merge(
+      species_traits, species_categories, by.x = colnames(species_traits)[1],
+      by.y = colnames(species_categories)[1]
+    )
+    
+    species_traits_categories <- split(
+      species_traits_categories[, -ncol(species_traits_categories)],
+      species_traits_categories[, ncol(species_traits_categories)]
+    )
+    
+    species_traits_long_categories <- merge(
+      species_traits_long, species_categories,
+      by.x = "species", by.y = colnames(species_categories)[1]
+    )
+    
+  }
   
-  all_traits <- sum(number_trait_per_species$n_traits == max_traits)
   
-  # Add "All Traits" in number of species per trait
+  # Count Number of Species per Trait (per category class)
+  number_species_per_trait <- lapply(
+    species_traits_categories, fb_count_species_by_trait
+  )
+  
+  # Get Combination for All Traits (per category class)
+  number_trait_per_species <- lapply(
+    species_traits_categories, fb_count_traits_by_species
+  )
+  
+  n_max_trait <- ncol(species_traits[, -1, drop = FALSE])
+  
+  # Get number of species with maximum known trait (per category)
+  all_traits_list <- lapply(
+    number_trait_per_species,
+    function(x) {
+      
+      with(x, sum(n_traits == n_max_trait))
+      
+    })
+  
+  
+  # Convert number of species with all traits into comparable row
   all_traits_df <- NULL
   
   if (all_traits) {
-    all_traits_df <- data.frame(
-      trait     = "all_traits",
-      n_species = all_traits,
-      coverage  = all_traits/nrow(species_traits)
+    
+    all_traits_df <- mapply(
+      function(x, y) {
+        data.frame(
+          trait     = "all_traits",
+          n_species = x,
+          coverage  = x/nrow(y)
+        )
+      }, all_traits_list, species_traits_categories, SIMPLIFY = FALSE,
+      USE.NAMES = FALSE
     )
+    
   }
   
-  number_species_per_trait <- rbind(
-    number_species_per_trait,
-    all_traits_df
+  # Add number of species with all traits known per category
+  number_species_per_trait <- mapply(
+    rbind, number_species_per_trait, all_traits_df, SIMPLIFY = FALSE,
+    USE.NAMES = FALSE
   )
   
   # Label with name of trait and proportion of species
-  number_species_per_trait$trait_label <- with(
-    number_species_per_trait,
-    paste0(trait, "\n(", round(coverage * 100, digits = 1), "%)")
+  number_species_per_trait <- lapply(
+    number_species_per_trait, 
+    function(x) {
+      x$trait_label <- paste0(
+        x$trait, "\n(", round(x$coverage * 100, digits = 1), "%)"
+      )
+      
+      return(x)
+    }
   )
+  
   
   # Add all traits in long table
-  species_traits_long <- rbind(
-    species_traits_long,
-    data.frame(
-      species = number_trait_per_species$species, trait_name = "all_traits",
-      trait_value = ifelse(
-        number_trait_per_species$n_traits == max_traits, TRUE, NA
-      )
+  if (is.null(names(number_trait_per_species))) {
+    names(number_trait_per_species) <- seq_len(
+      length(number_trait_per_species)
     )
+    names(number_species_per_trait) <- seq_len(
+      length(number_species_per_trait)
+    )
+  }
+  
+  all_traits_subset <- lapply(
+    names(number_trait_per_species), function(x) {
+      
+      single_category <- number_trait_per_species[[x]]
+      
+      output_df <- data.frame(
+        species = single_category$species, trait = "all_traits",
+        trait_value = ifelse(single_category$n_traits == n_max_trait, TRUE, NA)
+      )
+      
+      if (!is.null(species_categories)) {
+        output_df[[colnames(species_categories)[2]]] <- x
+      }
+      
+      return(output_df)
+    }
   )
   
-  # Add column for value
-  species_traits_long$has_trait <- ifelse(
-    !is.na(species_traits_long$trait_value), TRUE, FALSE
+  all_traits_subset <- do.call(rbind, all_traits_subset)
+  
+  species_traits_long_categories <- rbind(
+    species_traits_long_categories, all_traits_subset
   )
+  
+  
+  # Add column for value
+  species_traits_long_categories$has_trait <- ifelse(
+        !is.na(species_traits_long_categories$trait_value), TRUE, FALSE
+  )
+  
+  # Merge all datasets before plotting
+  number_species_per_trait <- lapply(
+    names(number_species_per_trait),
+    function(x) {
+      
+      single_category <- number_species_per_trait[[x]]
+      
+      if (!is.null(species_categories)) {
+        single_category[[colnames(species_categories)[2]]] <- x
+      }
+      
+      return(single_category)
+    }
+  )
+  number_species_per_trait <- do.call(rbind, number_species_per_trait)
+  
+  number_trait_per_species <- lapply(
+    names(number_trait_per_species),
+    function(x) {
+      
+      single_category <- number_trait_per_species[[x]]
+      
+      if (!is.null(species_categories)) {
+        single_category[[colnames(species_categories)[2]]] <- x
+      }
+      
+      return(single_category)
+    }
+  )
+  number_trait_per_species <- do.call(rbind, number_trait_per_species)
+  
+  
+  # Merge full dataset
+  common_colnames <- intersect(
+    colnames(species_traits_long_categories), colnames(number_species_per_trait)
+  )
+  
+  species_traits_long_categories <- merge(
+    species_traits_long_categories, number_species_per_trait,
+    by.x = common_colnames, by.y = common_colnames
+  )
+  
+  # Conditional facet
+  if (!is.null(species_categories)) {
+    
+    category_facet <- ggplot2::facet_wrap(
+      ggplot2::vars(
+        !!rlang::sym(colnames(species_categories)[[2]])), scales = "free"
+    )
+    
+  } else {
+    category_facet <- NULL
+  }
+  
+  # Clean environment for clean ggplot2 object
+  rm(all_traits, all_traits_df, all_traits_list, all_traits_subset,
+     common_colnames, n_max_trait, species_categories,
+     species_traits_categories, species_traits, species_traits_long)
+  
   
   # Plot Species x Trait completeness
   ggplot2::ggplot(
-    species_traits_long,
+    species_traits_long_categories,
     ggplot2::aes_q(
-      ~factor(trait_name, levels = number_species_per_trait$trait),
-      ~factor(species,    levels = number_trait_per_species$species)
+      ~factor(
+        trait_label, levels = unique(number_species_per_trait$trait_label)
+      ),
+      ~factor(
+        species, levels = unique(number_trait_per_species$species)
+      )
     )
   ) +
     ggplot2::geom_tile(
       ggplot2::aes_q(fill = ~has_trait)) +
+    category_facet +
     ggplot2::scale_x_discrete(
-      "Trait", labels = number_species_per_trait$trait_label,
-      guide = ggplot2::guide_axis(n.dodge = 2)
+      "Trait", guide = ggplot2::guide_axis(n.dodge = 2)
     ) +
     ggplot2::scale_y_discrete("Species", labels = NULL) +
     ggplot2::scale_fill_brewer(

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -10,7 +10,9 @@
 #' shows a summary considering if all other traits are known.
 #'
 #' @inheritParams fb_get_all_trait_coverages_by_site
-#' @inheritParams check_species_categories
+#' @param species_categories 2-columns `data.frame` giving species categories
+#'   `NULL` by default, with the first column describing the species name, and
+#'   the second column giving their corresponding categories
 #'
 #' @return a `ggplot2` object
 #'

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -92,7 +92,7 @@ fb_plot_species_traits_completeness <- function(
   
   
   # Convert number of species with all traits into comparable row
-  all_traits_df <- NULL
+  all_traits_df <- list(number_species_per_trait[[1]][0,])
   
   if (all_traits) {
     

--- a/R/fb_plot_trait_combination_frequencies.R
+++ b/R/fb_plot_trait_combination_frequencies.R
@@ -18,7 +18,7 @@
 #' fb_plot_trait_combination_frequencies(species_traits)
 #' 
 #' # Order by present traits
-#' fb_plot_trait_combination_frequencies(species_traits, "complete")
+#' fb_plot_trait_combination_frequencies(species_traits, NULL, "complete")
 #'
 #' @export
 #' @importFrom rlang .data

--- a/R/fb_plot_trait_combination_frequencies.R
+++ b/R/fb_plot_trait_combination_frequencies.R
@@ -23,72 +23,152 @@
 #' @export
 #' @importFrom rlang .data
 fb_plot_trait_combination_frequencies = function(
-    species_traits, order_by = c("number", "complete")
+    species_traits, species_categories = NULL,
+    order_by = c("number", "complete")
 ) {
   
   # Check arguments
   check_species_traits(species_traits)
+  check_species_categories(species_categories)
   order_by <- match.arg(order_by)
   
+  # Split species traits
+  species_traits_categories <- split_species_categories(
+    species_traits, species_categories
+  )
+  
   # Get data with combinations of values
-  combinations <- as.data.frame(
-    !is.na(species_traits[, -1, drop = FALSE])
+  combinations <- lapply(
+    species_traits_categories, function(x) {
+      as.data.frame(
+        !is.na(x[, -1, drop = FALSE])
+      )
+    }
   )
   
   # Get unique combinations and their count
-  unique_combinations <- stats::aggregate(
-    comb_count ~ ., cbind(combinations, comb_count = 1), FUN = sum
+  unique_combinations <- lapply(
+    combinations, function(x) {
+      stats::aggregate(
+        comb_count ~ ., cbind(x, comb_count = 1), FUN = sum
+      )
+    }
   )
   
   # Count number of present traits
-  number_traits <- rowSums(
-    unique_combinations[, seq(1, ncol(unique_combinations) - 1), drop = FALSE]
+  unique_combinations <- lapply(
+    unique_combinations, function(x) {
+      n_traits <- rowSums(
+        x[, seq(1, ncol(x) - 1), drop = FALSE]
+      )
+      
+      x$n_present <- n_traits
+      
+      return(x)
+    }
   )
   
-  unique_combinations$n_present <- number_traits
   
   # Order dataset based on 'order_by' argument
   if (order_by == "number") {
     
     # Order table by decreasing number of combinations
-    unique_combinations <- unique_combinations[
-      order(unique_combinations$comb_count, decreasing = TRUE),
-    ]
+    unique_combinations <- lapply(
+      unique_combinations, function(x) {
+        x[order(x$comb_count, decreasing = TRUE),]
+      }
+    )
     
   } else {
     
-    
-    
     # Order rows columns with most non-missing traits first then by count
-    unique_combinations <- unique_combinations[
-      order(unique_combinations$n_present, unique_combinations$comb_count,
-            decreasing = TRUE),
-    ]
+    unique_combinations <- lapply(
+      unique_combinations, function(x) {
+        x[order(x$n_present, x$comb_count, decreasing = TRUE),]
+      }
+    )
     
   }
   
   # Get row order
-  unique_combinations[["row_order"]] <- seq(nrow(unique_combinations))
-  
-  # Make table longer
-  unique_comb_long <- tidyr::pivot_longer(
-    unique_combinations, !c("comb_count", "row_order", "n_present"),
-    names_to = "trait_name", values_to = "trait_value"
+  unique_combinations <- lapply(
+    unique_combinations, function(x) {
+      x[["row_order"]] <- seq(nrow(x))
+      
+      return(x)
+    }
   )
   
+  # Make table longer
+  unique_comb_long <- mapply(
+    function(x, y) {
+      
+      x$trait_label <- paste0(
+        "n = ", x$comb_count," (",
+        round(x$comb_count / nrow(y) * 100, 1), "%)"
+      )
+      
+      # To disambiguate labels throughout- table
+      x$unique_label <- seq(nrow(x))
+      
+      long_df <- tidyr::pivot_longer(
+        x, !c("comb_count", "row_order", "n_present", "trait_label",
+              "unique_label"),
+        names_to = "trait_name", values_to = "trait_value"
+      )
+      
+      return(long_df)
+    }, unique_combinations, species_traits_categories, SIMPLIFY = FALSE
+  )
+  
+  # Manage conditional faceting
+  if (is.null(species_categories)) {
+    
+    category_facet <- NULL
+    
+  } else {
+    
+    unique_comb_long <- lapply(
+      names(unique_comb_long),
+      function(x) {
+        
+        single_category <- unique_comb_long[[x]]
+        
+        single_category[[colnames(species_categories)[2]]] <- x
+        
+        return(single_category)
+      }
+    )
+    
+    category_facet <- ggplot2::facet_wrap(
+      ggplot2::vars(
+        !!rlang::sym(colnames(species_categories)[[2]])), scales = "free"
+    )
+    
+  }
+  
+  unique_comb_long <- do.call(rbind, unique_comb_long)
+  
+  
+  # Tidy up environment
+  rm(combinations, order_by, species_categories, species_traits,
+     species_traits_categories, unique_combinations)
+  
+  
+  # Actual Plot
   ggplot2::ggplot(
-    unique_comb_long, ggplot2::aes(.data$trait_name, factor(.data$row_order))
+    unique_comb_long,
+    ggplot2::aes(
+      .data$trait_name, interaction(.data$trait_label, .data$unique_label)
+    )
   ) +
     ggplot2::geom_tile(
       ggplot2::aes(fill = .data$trait_value), color = "white"
     ) +
+    category_facet +
     ggplot2::scale_y_discrete(
       "Number and Proportion of Species",
-      labels = paste0(
-        "n = ", unique_combinations$comb_count," (",
-        round(unique_combinations$comb_count / nrow(species_traits) * 100, 1),
-        "%)"
-      )
+      labels = function(x) unlist(strsplit(x, "\\.[0-9]+$"))
     ) +
     ggplot2::scale_fill_brewer(
       "Trait", palette = "Set1",

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,3 +12,32 @@ weighted_mean <- function(x, w, ..., na.rm = FALSE){
   }
   weighted.mean(x, w, ..., na.rm = FALSE)
 }
+
+#' Function to split species traits data.frame into a list based on provided
+#' species categories
+#' 
+#' @noRd
+split_species_categories <- function(
+    species_traits, species_categories = NULL
+  ) {
+  
+  species_traits_categories <- list(species_traits)
+  
+  if (!is.null(species_categories)) {
+    
+    species_traits_categories <- merge(
+      species_traits, species_categories, by = colnames(species_categories)[1]
+    )
+    
+    species_traits_categories <- split(
+      species_traits_categories[
+        , -ncol(species_traits_categories), drop = FALSE
+      ],
+      species_traits_categories[, ncol(species_traits_categories)]
+    )
+    
+  }
+  
+  return(species_traits_categories)
+  
+}

--- a/man/fb_plot_number_species_by_trait.Rd
+++ b/man/fb_plot_number_species_by_trait.Rd
@@ -6,6 +6,7 @@
 \usage{
 fb_plot_number_species_by_trait(
   species_traits,
+  species_categories = NULL,
   threshold_species_proportion = NULL
 )
 }
@@ -14,6 +15,10 @@ fb_plot_number_species_by_trait(
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{threshold_species_proportion}{\code{numeric(1)} [default = \code{NULL}]\cr{}
 between 0 and 1. The percentage of species coverage threshold.}
@@ -31,6 +36,6 @@ data(species_traits)
 fb_plot_number_species_by_trait(species_traits)
 
 # Add a vertical cutoff line (12.5\% of species)
-fb_plot_number_species_by_trait(species_traits, 1/8)
+fb_plot_number_species_by_trait(species_traits, NULL, 1/8)
 
 }

--- a/man/fb_plot_number_traits_by_species.Rd
+++ b/man/fb_plot_number_traits_by_species.Rd
@@ -6,6 +6,7 @@
 \usage{
 fb_plot_number_traits_by_species(
   species_traits,
+  species_categories = NULL,
   threshold_species_proportion = NULL
 )
 }
@@ -14,6 +15,10 @@ fb_plot_number_traits_by_species(
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{threshold_species_proportion}{\code{numeric(1)} [default = \code{NULL}]\cr{}
 between 0 and 1. The percentage of species coverage threshold.}
@@ -33,6 +38,8 @@ data(species_traits)
 fb_plot_number_traits_by_species(species_traits)
 
 # Add a vertical cutoff line (33\% of the species)
-fb_plot_number_traits_by_species(species_traits, 1/3)
+fb_plot_number_traits_by_species(
+  species_traits, threshold_species_proportion = 1/3
+ )
 
 }

--- a/man/fb_plot_site_traits_completeness.Rd
+++ b/man/fb_plot_site_traits_completeness.Rd
@@ -7,6 +7,7 @@
 fb_plot_site_traits_completeness(
   site_species,
   species_traits,
+  species_categories = NULL,
   all_traits = TRUE
 )
 }
@@ -19,6 +20,10 @@ names. The other columns should be named according to species names.}
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{all_traits}{a logical (default = \code{TRUE}) which tell if the coverage
 considering all provided traits should be provided in an additional column

--- a/man/fb_plot_species_traits_completeness.Rd
+++ b/man/fb_plot_species_traits_completeness.Rd
@@ -4,13 +4,21 @@
 \alias{fb_plot_species_traits_completeness}
 \title{Plot Trait Coverage per Species for each Trait}
 \usage{
-fb_plot_species_traits_completeness(species_traits, all_traits = TRUE)
+fb_plot_species_traits_completeness(
+  species_traits,
+  species_categories = NULL,
+  all_traits = TRUE
+)
 }
 \arguments{
 \item{species_traits}{a \code{data.frame} with species in rows and
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{all_traits}{a logical (default = \code{TRUE}) which tell if the coverage
 considering all provided traits should be provided in an additional column

--- a/man/fb_plot_trait_combination_frequencies.Rd
+++ b/man/fb_plot_trait_combination_frequencies.Rd
@@ -6,6 +6,7 @@
 \usage{
 fb_plot_trait_combination_frequencies(
   species_traits,
+  species_categories = NULL,
   order_by = c("number", "complete")
 )
 }
@@ -14,6 +15,10 @@ fb_plot_trait_combination_frequencies(
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{order_by}{{\code{character(1)} either \code{"number"} or \verb{"complete}}\cr{}
 If \code{"number"} order rows by frequency so that most
@@ -34,6 +39,6 @@ represents one trait. The y-axis gives the frequency of the row
 fb_plot_trait_combination_frequencies(species_traits)
 
 # Order by present traits
-fb_plot_trait_combination_frequencies(species_traits, "complete")
+fb_plot_trait_combination_frequencies(species_traits, NULL, "complete")
 
 }

--- a/man/fb_plot_trait_correlation.Rd
+++ b/man/fb_plot_trait_correlation.Rd
@@ -4,13 +4,17 @@
 \alias{fb_plot_trait_correlation}
 \title{Plot Trait Correlation Matrix}
 \usage{
-fb_plot_trait_correlation(species_traits, ...)
+fb_plot_trait_correlation(species_traits, species_categories = NULL, ...)
 }
 \arguments{
 \item{species_traits}{a \code{data.frame} with species in rows and
 traits as columns. \strong{NOTE}: The first column should be named \strong{\code{"species"}}
 and contain species names. The other columns should be named according
 to trait names.}
+
+\item{species_categories}{2-columns \code{data.frame} giving species categories
+\code{NULL} by default, with the first column describing the species name, and
+the second column giving their corresponding categories}
 
 \item{...}{Additional options passed to \code{\link[stats:cor]{stats::cor()}}}
 }

--- a/tests/testthat/test-fb_format_site_locations.R
+++ b/tests/testthat/test-fb_format_site_locations.R
@@ -233,7 +233,7 @@ test_that("fb_format_site_locations() works with valid input", {
   expect_equal(nrow(site_locations), 32L)
   expect_equal(ncol(site_locations), 2L)
   expect_true("site" %in% colnames(site_locations))
-  expect_equal(sf::st_coordinates(site_locations)[1, 1], 59.097357)
+  expect_equal(sf::st_coordinates(site_locations)[1, 1][[1]], 59.097357)
   
   
   # Including NA values

--- a/tests/testthat/test-fb_plot_number_species_by_trait.R
+++ b/tests/testthat/test-fb_plot_number_species_by_trait.R
@@ -4,8 +4,65 @@ test_that("fb_plot_number_species_by_trait works", {
   expect_s3_class(given_plot, "ggplot")
   
   expect_silent(
-    given_plot <- fb_plot_number_species_by_trait(species_traits, 25)
+    given_plot <- fb_plot_number_species_by_trait(
+      species_traits, threshold_species_proportion = 25
+    )
   )
   
   expect_s3_class(given_plot, "ggplot")
+  
+  # Check with non-continuous traits
+  example_traits <- data.frame(
+    species = letters[1:3],
+    trait1  = 1:3,
+    trait2  = LETTERS[1:3]
+  )
+  
+  expect_silent(
+    given_plot <- fb_plot_number_species_by_trait(example_traits)
+  )
+  
+  # Test that function works with a single trait
+  
+  expect_silent(
+    given_plot <- fb_plot_number_species_by_trait(example_traits[, 1:2])
+  )
+  
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_number_species_by_trait(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = "A")
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_number_species_by_trait(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = c(1, 1, 2))
+    )
+  )
+  
+  # As many categories as species
+  expect_silent(
+    given_plot <- fb_plot_number_species_by_trait(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = example_traits$species)
+    )
+  )
+})
+
+test_that("fb_plot_number_species_by_trait() fails gracefully", {
+  
+  expect_error(
+    fb_plot_number_species_by_trait(species_traits, FALSE),
+    "'species_categories' isn't a two-column data.frame"
+  )
+  
 })

--- a/tests/testthat/test-fb_plot_number_traits_by_species.R
+++ b/tests/testthat/test-fb_plot_number_traits_by_species.R
@@ -57,6 +57,7 @@ test_that("fb_plot_number_traits_by_species works", {
                  category = example_traits$species)
     )
   )
+  
 })
 
 test_that("fb_plot_number_traits_by_species() fails gracefully", {

--- a/tests/testthat/test-fb_plot_number_traits_by_species.R
+++ b/tests/testthat/test-fb_plot_number_traits_by_species.R
@@ -5,8 +5,65 @@ test_that("fb_plot_number_traits_by_species works", {
   
   
   expect_silent(
-    given_plot <- fb_plot_number_traits_by_species(species_traits, 3)
+    given_plot <- fb_plot_number_traits_by_species(
+      species_traits, threshold_species_proportion = 1/3
+    )
   )
   
   expect_s3_class(given_plot, "ggplot")
+  
+  # Check with non-continuous traits
+  example_traits <- data.frame(
+    species = letters[1:3],
+    trait1  = 1:3,
+    trait2  = LETTERS[1:3]
+  )
+  
+  expect_silent(
+    given_plot <- fb_plot_number_traits_by_species(example_traits)
+  )
+  
+  # Test that function works with a single trait
+  
+  expect_silent(
+    given_plot <- fb_plot_number_traits_by_species(example_traits[, 1:2])
+  )
+  
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_number_traits_by_species(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = "A")
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_number_traits_by_species(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = c(1, 1, 2))
+    )
+  )
+  
+  # As many categories as species
+  expect_silent(
+    given_plot <- fb_plot_number_traits_by_species(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = example_traits$species)
+    )
+  )
+})
+
+test_that("fb_plot_number_traits_by_species() fails gracefully", {
+  
+  expect_error(
+    fb_plot_number_traits_by_species(species_traits, FALSE),
+    "'species_categories' isn't a two-column data.frame"
+  )
+  
 })

--- a/tests/testthat/test-fb_plot_site_traits_completeness.R
+++ b/tests/testthat/test-fb_plot_site_traits_completeness.R
@@ -7,9 +7,30 @@ test_that("fb_plot_site_traits_completeness works", {
   
   expect_silent(
     given_plot <- fb_plot_site_traits_completeness(
-      site_species, species_traits, FALSE
+      site_species, species_traits, NULL, FALSE
     )
   )
   
   expect_s3_class(given_plot, "ggplot")
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_site_traits_completeness(
+      site_species, species_traits,
+      data.frame(species  = species_traits$species,
+                 category = "A")
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_site_traits_completeness(
+      site_species, species_traits,
+      data.frame(
+        species  = species_traits$species,
+        category = sample(letters[1:3], nrow(species_traits), replace = TRUE)
+      )
+    )
+  )
 })

--- a/tests/testthat/test-fb_plot_species_traits_completeness.R
+++ b/tests/testthat/test-fb_plot_species_traits_completeness.R
@@ -7,7 +7,9 @@ test_that("fb_plot_species_traits_completeness works", {
   
   # Without 'all_traits' added
   expect_silent(
-    given_plot <- fb_plot_species_traits_completeness(species_traits, FALSE)
+    given_plot <- fb_plot_species_traits_completeness(
+      species_traits, all_traits =  FALSE
+    )
   )
   
   expect_s3_class(given_plot, "ggplot")
@@ -20,15 +22,58 @@ test_that("fb_plot_species_traits_completeness works", {
   )
   
   expect_silent(
-    given_plot <- fb_plot_species_traits_completeness(example_traits, FALSE)
+    given_plot <- fb_plot_species_traits_completeness(
+      example_traits, all_traits = FALSE
+    )
   )
   
-  # Test that function works with single trait
+  # Test that function works with a single trait
   
   expect_silent(
     given_plot <- fb_plot_species_traits_completeness(
-      example_traits[, 1:2], FALSE
+      example_traits[, 1:2], all_traits = FALSE
     )
+  )
+  
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_species_traits_completeness(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = "A"),
+      all_traits = FALSE
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_species_traits_completeness(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = c(1, 1, 2)),
+      all_traits = FALSE
+    )
+  )
+  
+  # As many categories as species
+  expect_silent(
+    given_plot <- fb_plot_species_traits_completeness(
+      example_traits,
+      data.frame(species  = example_traits$species,
+                 category = example_traits$species),
+      all_traits = FALSE
+    )
+  )
+  
+})
+
+test_that("fb_plot_species_traits_completeness() fails gracefully", {
+  
+  expect_error(
+    fb_plot_species_traits_completeness(species_traits, FALSE),
+    "'species_categories' isn't a two-column data.frame"
   )
   
 })

--- a/tests/testthat/test-fb_plot_species_traits_completeness.R
+++ b/tests/testthat/test-fb_plot_species_traits_completeness.R
@@ -8,7 +8,7 @@ test_that("fb_plot_species_traits_completeness works", {
   # Without 'all_traits' added
   expect_silent(
     given_plot <- fb_plot_species_traits_completeness(
-      species_traits, all_traits =  FALSE
+      species_traits, all_traits = FALSE
     )
   )
   

--- a/tests/testthat/test-fb_plot_trait_combination_frequencies.R
+++ b/tests/testthat/test-fb_plot_trait_combination_frequencies.R
@@ -6,8 +6,41 @@ test_that("fb_plot_trait_combination_frequencies() works", {
   expect_s3_class(res, "ggplot")
   
   expect_silent(
-    res <- fb_plot_trait_combination_frequencies(species_traits, "complete")
+    res <- fb_plot_trait_combination_frequencies(
+      species_traits, NULL, "complete"
+    )
   )
   
   expect_s3_class(res, "ggplot")
+  
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_trait_combination_frequencies(
+      species_traits,
+      data.frame(species  = species_traits$species,
+                 category = "A")
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_trait_combination_frequencies(
+      species_traits,
+      data.frame(
+        species  = species_traits$species,
+        category = sample(letters[1:3], nrow(species_traits), replace = TRUE)
+      )
+    )
+  )
+  
+  # As many categories as species
+  expect_silent(
+    given_plot <- fb_plot_trait_combination_frequencies(
+      species_traits,
+      data.frame(species  = species_traits$species,
+                 category = species_traits$species)
+    )
+  )
 })

--- a/tests/testthat/test-fb_plot_trait_correlation.R
+++ b/tests/testthat/test-fb_plot_trait_correlation.R
@@ -1,7 +1,8 @@
 # Initial data -----------------------------------------------------------------
 
 sp_trait <- data.frame(species = letters[1:3], trait1 = letters[1:3],
-                       trait2  = 1:3)
+                       trait2  = 1:3, trait3 = 3:1)
+
 
 # Actual Tests -----------------------------------------------------------------
 
@@ -30,4 +31,29 @@ test_that("fb_plot_trait_correlation() works", {
   )
   
   expect_s3_class(res, "ggplot")
+  
+  ## Works with species categories
+  # Single category 
+  expect_silent(
+    given_plot <- fb_plot_trait_correlation(
+      sp_trait[, -2], data.frame(species  = sp_trait$species, category = "A")
+    )
+  )
+  
+  # Less categories than species
+  expect_silent(
+    given_plot <- fb_plot_trait_correlation(
+      sp_trait[, -2],
+      data.frame(species  = sp_trait$species, category = c(1, 1, 2))
+    )
+  )
+  
+  # As many categories as species
+  expect_silent(
+    given_plot <- fb_plot_trait_correlation(
+      sp_trait[, -2],
+      data.frame(species  = sp_trait$species,
+                 category = sp_trait$species)
+    )
+  )
 })

--- a/vignettes/diagnostic-plots.Rmd
+++ b/vignettes/diagnostic-plots.Rmd
@@ -121,7 +121,7 @@ proportion of species. Let's say we want to see traits available for at least
 70% of the species:
 
 ```{r plot-species-coverage-trait-thresh}
-fb_plot_number_species_by_trait(species_traits, 0.7)
+fb_plot_number_species_by_trait(species_traits, threshold_species_proportion = 0.7)
 ```
 
 The red dashed vertical line shows the corresponding species coverage with
@@ -165,7 +165,7 @@ Let's say we're interested in combinations of traits with at least 50% species
 covered. We can use the second argument to show it:
 
 ```{r plot-n-traits-species-thresh}
-fb_plot_number_traits_by_species(species_traits, 0.5)
+fb_plot_number_traits_by_species(species_traits, threshold_species_proportion = 0.5)
 ```
 
 Adding this argument displays a vertical bar at the target proportion of species

--- a/vignettes/funbiogeo.Rmd
+++ b/vignettes/funbiogeo.Rmd
@@ -181,7 +181,7 @@ For example, if we want to visualize which traits cover more than 75%
 of the species:
 
 ```{r fig-plot-sp-by-trait-prop}
-fb_plot_number_species_by_trait(species_traits, 0.75)
+fb_plot_number_species_by_trait(species_traits, threshold_species_proportion = 0.75)
 ```
 
 The top number shows the corresponding number of species.


### PR DESCRIPTION
This PR is a WIP to implement species categories (see #15) across `funbiogeo` especially the plotting function.

For now, I have the impression that it complexifies significantly the code. But there may be more efficient ways to do so.
I'll progress plot function per plot function.

Current implementation in plotting functions:

- [x] ~~fb_map_raster()~~ *not applicable*
- [x] ~~fb_map_site_data()~~ *not applicable*
- [ ] fb_map_site_traits_completeness()
- [ ] fb_plot_distribution_site_trait_coverage()
- [ ] fb_plot_number_sites_by_species()
- [x] fb_plot_number_species_by_trait()
- [x] fb_plot_number_traits_by_species()
- [x] ~~fb_plot_site_environment()~~ *not applicable*
- [x] fb_plot_site_traits_completeness()
- [x] fb_plot_species_traits_completeness()
- [x] fb_plot_trait_combination_frequencies()
- [x] fb_plot_trait_correlation()
- [x] ~~fb_table_trait_summary()~~ *not applicable*
