### PR TITLE
Check column names

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -158,6 +158,11 @@ check_site_locations <- function(site_locations) {
     stop("The site x locations object should have at least one row", 
          call. = FALSE)
   }
+
+  if (!("site" %in% colnames(site_locations))) {
+    stop("The site x locations object must contain the 'site' column", 
+         call. = FALSE)
+  }
   
   invisible(NULL)
 }
@@ -273,5 +278,11 @@ check_species_categories <- function(species_categories) {
   ) {
     stop("'species_categories' isn't a two-column data.frame", call. = FALSE)
   }
+
+  if (!("species" %in% colnames(species_categories))) {
+    stop("The species x categories object must contain the 'species' column", 
+         call. = FALSE)
+  }
   
+  invisible(NULL)
 }

--- a/R/checks.R
+++ b/R/checks.R
@@ -292,11 +292,6 @@ check_species_categories <- function(species_categories) {
       stop("The species x categories object must have two columns (species ", 
            "name and one category)", call. = FALSE)
     }
-
-    if (is.null(colnames(species_categories))) {
-      stop("The species x categories object must have column names",
-           call. = FALSE)
-    }
     
     if (!("species" %in% colnames(species_categories))) {
       stop("The species x categories object must contain the 'species' column",

--- a/R/checks.R
+++ b/R/checks.R
@@ -270,18 +270,36 @@ check_object_name <- function(object) {
 #'   the second column giving their corresponding categories
 #'
 #' @noRd
+
 check_species_categories <- function(species_categories) {
   
-  if (
-    !is.null(species_categories) &
-    (!is.data.frame(species_categories) | sum(ncol(species_categories)) != 2)
-  ) {
-    stop("'species_categories' isn't a two-column data.frame", call. = FALSE)
-  }
-
+  
+  # Only if it's not NULL ------------------------------------------------------
+  
   if (!is.null(species_categories)) {
+    
+    if (!is.data.frame(species_categories)) {
+      stop("The species x categories object must be a data.frame", 
+           call. = FALSE)
+    }
+
+    if (nrow(species_categories) < 1L) {
+      stop("The species x categories object should have at least one row", 
+           call. = FALSE)
+    }
+
+    if (ncol(species_categories) != 2L) {
+      stop("The species x categories object must have two columns (species ", 
+           "name and one category)", call. = FALSE)
+    }
+
+    if (is.null(colnames(species_categories))) {
+      stop("The species x categories object must have column names",
+           call. = FALSE)
+    }
+    
     if (!("species" %in% colnames(species_categories))) {
-      stop("The species x categories object must contain the 'species' column", 
+      stop("The species x categories object must contain the 'species' column",
            call. = FALSE)
     }
   }

--- a/R/checks.R
+++ b/R/checks.R
@@ -279,9 +279,11 @@ check_species_categories <- function(species_categories) {
     stop("'species_categories' isn't a two-column data.frame", call. = FALSE)
   }
 
-  if (!("species" %in% colnames(species_categories))) {
-    stop("The species x categories object must contain the 'species' column", 
-         call. = FALSE)
+  if (!is.null(species_categories)) {
+    if (!("species" %in% colnames(species_categories))) {
+      stop("The species x categories object must contain the 'species' column", 
+           call. = FALSE)
+    }
   }
   
   invisible(NULL)

--- a/R/fb_count_sites_by_species.R
+++ b/R/fb_count_sites_by_species.R
@@ -26,17 +26,19 @@ fb_count_sites_by_species <- function(site_species) {
   
   ## Compute sites coverage by species ----
   
-  sites_coverage <- unlist(lapply(colnames(site_species)[-1], function(x) 
-    sum(!is.na(site_species[[x]]) & site_species[[x]] > 0)))
+  sites_coverage <- unlist(
+    lapply(colnames(drop_column(site_species, "site")), function(x) 
+      sum(!is.na(site_species[[x]]) & site_species[[x]] > 0))
+  )
   
   sites_coverage <- data.frame(
-    "species"  = colnames(site_species)[-1],
+    "species"  = colnames(drop_column(site_species, "site")),
     "n_sites"  = sites_coverage,
     "coverage" = sites_coverage / nrow(site_species)
   )
   
-  sites_coverage <- sites_coverage[order(sites_coverage$"coverage", 
-                                         decreasing = TRUE), ]
+  sites_coverage <- sites_coverage[
+    order(sites_coverage$"coverage", decreasing = TRUE), ]
   
   rownames(sites_coverage) <- NULL
   

--- a/R/fb_count_species_by_site.R
+++ b/R/fb_count_species_by_site.R
@@ -28,13 +28,14 @@ fb_count_species_by_site <- function(site_species) {
   ## Compute species coverage by site ----
   
   species_coverage <- apply(
-    site_species[ , -1], 1, function(x) sum(!is.na(x) & x > 0)
+    drop_column(site_species, "site"), 1, function(x) 
+      sum(!is.na(x) & x > 0)
   )
   
   species_coverage <- data.frame(
-    "site"      = site_species[ , 1],
+    "site"      = site_species[["site"]],
     "n_species" = species_coverage,
-    "coverage"  = species_coverage / ncol(site_species[ , -1]))
+    "coverage"  = species_coverage / (ncol(site_species) - 1))
   
   species_coverage <- species_coverage[
     order(species_coverage$"coverage", decreasing = TRUE),

--- a/R/fb_count_species_by_trait.R
+++ b/R/fb_count_species_by_trait.R
@@ -24,13 +24,15 @@ fb_count_species_by_trait <- function(species_traits) {
   
   
   # Compute species coverage by trait
-  species_coverage <- unlist(lapply(colnames(species_traits)[-1], function(x) 
-    sum(!is.na(species_traits[[x]]))))
+  species_coverage <- unlist(
+    lapply(colnames(drop_column(species_traits, "species")), function(x) 
+      sum(!is.na(species_traits[[x]])))
+  )
   
   species_coverage <- data.frame(
-    "trait"      = colnames(species_traits)[-1],
-    "n_species"  = species_coverage,
-    "coverage"   = species_coverage / nrow(species_traits))
+    "trait"     = colnames(drop_column(species_traits, "species")),
+    "n_species" = species_coverage,
+    "coverage"  = species_coverage / nrow(species_traits))
   
   species_coverage <- species_coverage[order(species_coverage$"coverage", 
                                              decreasing = TRUE), ]

--- a/R/fb_count_traits_by_species.R
+++ b/R/fb_count_traits_by_species.R
@@ -25,11 +25,11 @@ fb_count_traits_by_species <- function(species_traits) {
   
   
   # Compute traits coverage by species
-  traits_coverage <- apply(species_traits[ , -1, drop = FALSE], 1, function(x)
-    sum(!is.na(x)))
+  traits_coverage <- apply(
+    drop_column(species_traits, "species"), 1, function(x) sum(!is.na(x)))
   
   traits_coverage <- data.frame(
-    "species"    = species_traits[ , 1],
+    "species"    = species_traits[["species"]],
     "n_traits"   = traits_coverage,
     "coverage"   = traits_coverage / (ncol(species_traits) - 1))
   

--- a/R/fb_cwm.R
+++ b/R/fb_cwm.R
@@ -27,14 +27,14 @@ fb_cwm <- function(site_species, species_traits) {
   
   # Get species in common between both matrices
   species <- list_common_species(
-    colnames(site_species), species_traits[["species"]]
+    colnames(drop_column(site_species, "site")), species_traits[["species"]]
   )
   
   
   # Select quantitative traits for CWM
   quanti_traits  <- vapply(species_traits, is.numeric, TRUE)
   quanti_traits[["species"]] <- TRUE
-  species_traits <- species_traits[, quanti_traits, drop = FALSE]
+  species_traits <- species_traits[ , quanti_traits, drop = FALSE]
   
 
   if (sum(quanti_traits) <= 1) {
@@ -58,7 +58,7 @@ fb_cwm <- function(site_species, species_traits) {
   
   # Extracting Trait Matrix
   trait_matrix <- species_traits[
-    species_traits[["species"]] %in% species,, drop = FALSE
+    species_traits[["species"]] %in% species, , drop = FALSE
   ]
   
   if (any(is.na(trait_matrix))) {

--- a/R/fb_filter_sites_by_species_coverage.R
+++ b/R/fb_filter_sites_by_species_coverage.R
@@ -52,7 +52,7 @@ fb_filter_sites_by_species_coverage <- function(
   } else {
     
     returned_sites <- site_species[
-      site_species[ , 1] %in% selected_sites, , drop = FALSE
+      site_species[["site"]] %in% selected_sites, , drop = FALSE
     ]
   }
   

--- a/R/fb_filter_sites_by_trait_coverage.R
+++ b/R/fb_filter_sites_by_trait_coverage.R
@@ -56,7 +56,7 @@ fb_filter_sites_by_trait_coverage <- function(
     
     message("No sites has the specified trait coverage threshold")
     
-    returned_sites <- site_species[NULL,]
+    returned_sites <- site_species[NULL, ]
   
   } else {
     

--- a/R/fb_filter_species_by_trait_coverage.R
+++ b/R/fb_filter_species_by_trait_coverage.R
@@ -51,7 +51,7 @@ fb_filter_species_by_trait_coverage <- function(
   } else {
     
     returned_traits <- species_traits[
-      species_traits[ , 1] %in% selected_species, , drop = FALSE
+      species_traits[["species"]] %in% selected_species, , drop = FALSE
     ]
     
   }

--- a/R/fb_filter_traits_by_species_coverage.R
+++ b/R/fb_filter_traits_by_species_coverage.R
@@ -46,7 +46,7 @@ fb_filter_traits_by_species_coverage <- function(
     "trait"]
   
   returned_traits <- species_traits[
-    , c(colnames(species_traits)[1], selected_traits), drop = FALSE
+    , c("species", selected_traits), drop = FALSE
   ]
   
   if (identical(selected_traits, character(0))) {

--- a/R/fb_format_site_locations.R
+++ b/R/fb_format_site_locations.R
@@ -178,19 +178,24 @@ fb_format_site_locations <- function(
   
   data <- data[ , c(site, longitude, latitude)]
   
+
+  ## Rename 'site' column ----
+
+  colnames(data)[1] <- "site"
+
   
   ## Replace non-alphanumeric characters ---------------------------------------
   
-  data[ , site] <- gsub("\\s|[[:punct:]]", "_", data[ , site])
-  data[ , site] <- gsub("_{1,}", "_",           data[ , site])
-  data[ , site] <- gsub("^_|_$", "",            data[ , site])
+  data[["site"]] <- gsub("\\s|[[:punct:]]", "_", data[["site"]])
+  data[["site"]] <- gsub("_{1,}", "_",           data[["site"]])
+  data[["site"]] <- gsub("^_|_$", "",            data[["site"]])
   
   
   ## Remove sites with NA ------------------------------------------------------
   
   if (na_rm) {
-    data <- data[!is.na(data[ , longitude]), ]
-    data <- data[!is.na(data[ , latitude]), ]
+    data <- data[!is.na(data[("longitude")]), ]
+    data <- data[!is.na(data[("latitude")]), ]
   }
   
   

--- a/R/fb_format_site_species.R
+++ b/R/fb_format_site_species.R
@@ -141,15 +141,21 @@ fb_format_site_species <- function(data, site, species, value,
   data <- data[ , c(site, species, value)]
   
   
+  ## Rename 'site' & 'species' columns ----
+
+  colnames(data)[1] <- "site"
+  colnames(data)[2] <- "species"
+
+
   ## Replace non-alphanumeric characters ---------------------------------------
   
-  data[ , site] <- gsub("\\s|[[:punct:]]", "_", data[ , site])
-  data[ , site] <- gsub("_{1,}", "_", data[ , site])
-  data[ , site] <- gsub("^_|_$", "", data[ , site])
+  data[["site"]] <- gsub("\\s|[[:punct:]]", "_", data[["site"]])
+  data[["site"]] <- gsub("_{1,}", "_",           data[["site"]])
+  data[["site"]] <- gsub("^_|_$", "",            data[["site"]])
   
-  data[ , species] <- gsub("\\s|[[:punct:]]", "_", data[ , species])
-  data[ , species] <- gsub("_{1,}", "_", data[ , species])
-  data[ , species] <- gsub("^_|_$", "", data[ , species])
+  data[["species"]] <- gsub("\\s|[[:punct:]]", "_", data[["species"]])
+  data[["species"]] <- gsub("_{1,}", "_",           data[["species"]])
+  data[["species"]] <- gsub("^_|_$", "",            data[["species"]])
   
   
   ## From long to wider format -------------------------------------------------

--- a/R/fb_format_species_categories.R
+++ b/R/fb_format_species_categories.R
@@ -105,26 +105,30 @@ fb_format_species_categories <- function(data, species, category) {
   data <- data[ , c(species, category)]
   
   
+  ## Rename 'species' column ----
+
+  colnames(data)[1] <- "species"
+  
+  
   ## Replace non-alphanumeric characters ---------------------------------------
   
-  data[ , species] <- gsub("\\s|[[:punct:]]|_{1,}", "_", data[ , species])
-  data[ , species] <- gsub("^_|_$", "", data[ , species])
+  data[["species"]] <- gsub("\\s|[[:punct:]]|_{1,}", "_", data[["species"]])
+  data[["species"]] <- gsub("^_|_$", "",                  data[["species"]])
   
   data[ , category] <- gsub("\\s|[[:punct:]]|_{1,}", "_", data[ , category])
-  data[ , category] <- gsub("^_|_$", "", data[ , category])
+  data[ , category] <- gsub("^_|_$", "",                  data[ , category])
   
   
   ## Remove duplicated rows ----------------------------------------------------
   
-  n_cat_per_sp <- tapply(data[ , category], data[ , species], function(x) 
+  n_cat_per_sp <- tapply(data[ , category], data[["species"]], function(x) 
     length(unique(x)))
   
   if (any(n_cat_per_sp > 1)) {
     stop("Some species have non-unique category values", call. = FALSE)
   }
   
-  data <- data[which(!duplicated(data[ , species])), ]
-  
+  data <- data[which(!duplicated(data[["species"]])), ]
   
   data
 }

--- a/R/fb_format_species_traits.R
+++ b/R/fb_format_species_traits.R
@@ -95,11 +95,16 @@ fb_format_species_traits <- function(data, species, traits) {
   data <- data[ , c(species, traits)]
   
   
+  ## Rename 'species' column ----
+
+  colnames(data)[1] <- "species"
+  
+  
   ## Replace non-alphanumeric characters ---------------------------------------
 
-  data[ , species] <- gsub("\\s|[[:punct:]]", "_", data[ , species])
-  data[ , species] <- gsub("_{1,}", "_", data[ , species])
-  data[ , species] <- gsub("^_|_$", "", data[ , species])
+  data[["species"]] <- gsub("\\s|[[:punct:]]", "_", data[["species"]])
+  data[["species"]] <- gsub("_{1,}", "_",           data[["species"]])
+  data[["species"]] <- gsub("^_|_$", "",            data[["species"]])
   
   
   ## Get unique traits values per species --------------------------------------
@@ -109,7 +114,7 @@ fb_format_species_traits <- function(data, species, traits) {
   
   for (trait in traits) {
     
-    trait_values[[trait]] <- tapply(data[ , trait], data[ , species], 
+    trait_values[[trait]] <- tapply(data[ , trait], data[["species"]], 
                                     function(x) unique(x))
     
     if (length(unique(unlist(lapply(trait_values[[trait]], length)))) > 1) {

--- a/R/fb_get_all_trait_coverages_by_site.R
+++ b/R/fb_get_all_trait_coverages_by_site.R
@@ -49,17 +49,19 @@ fb_get_all_trait_coverages_by_site <- function(
   }
   
   # Trait by Trait
-  trait_coverage <- lapply(colnames(species_traits)[-1], function(x) {
+  trait_coverage <- lapply(colnames(drop_column(species_traits, "species")), 
+    function(x) {
     
-    single_trait_coverage <- fb_get_trait_coverage_by_site(
-      site_species, species_traits[, c("species", x)]
-    )
+      single_trait_coverage <- fb_get_trait_coverage_by_site(
+        site_species, species_traits[, c("species", x)]
+      )
     
-    colnames(single_trait_coverage)[2] <- x
+      colnames(single_trait_coverage)[2] <- x
     
-    return(single_trait_coverage)
+      return(single_trait_coverage)
   })
   
+
   # Combine Trait by Trait Coverages
   trait_coverage <- Reduce(
     function(...) merge(..., by = "site", all.x = TRUE), trait_coverage

--- a/R/fb_get_trait_combination_coverage.R
+++ b/R/fb_get_trait_combination_coverage.R
@@ -71,7 +71,7 @@ fb_get_trait_combination_coverage = function(
   }
   
   # Generate all combinations of trait to use
-  traits = colnames(species_traits)[-1]
+  traits = colnames(drop_column(species_traits, "species"))
   
   all_combinations = lapply(
     target_combs,
@@ -89,7 +89,7 @@ fb_get_trait_combination_coverage = function(
     function(combination) {
       
       trait_coverage = fb_get_trait_coverage_by_site(
-        site_species, species_traits[, c("species", combination)]
+        site_species, species_traits[ , c("species", combination)]
       )
       
       combination_length = length(combination)

--- a/R/fb_get_trait_coverage_by_site.R
+++ b/R/fb_get_trait_coverage_by_site.R
@@ -39,7 +39,7 @@ fb_get_trait_coverage_by_site <- function(site_species, species_traits) {
   
   # Get species in common between both matrices
   species <- list_common_species(
-    colnames(site_species), species_traits[["species"]]
+    colnames(drop_column(site_species, "site")), species_traits[["species"]]
   )
   
   # Take species with NA into account
@@ -50,13 +50,13 @@ fb_get_trait_coverage_by_site <- function(site_species, species_traits) {
   
   # Subset data with common species
   species_traits <- species_traits[
-    species_traits[["species"]] %in% species,, drop = FALSE
+    species_traits[["species"]] %in% species, , drop = FALSE
   ]
   
   
   # Count all species (presence/abundance) per site
   site_total_abundance <- rowSums(
-    site_species[ , -1, drop = FALSE], na.rm = TRUE
+    drop_column(site_species, "site"), na.rm = TRUE
   )
   
   

--- a/R/fb_plot_distribution_site_trait_coverage.R
+++ b/R/fb_plot_distribution_site_trait_coverage.R
@@ -36,10 +36,11 @@ fb_plot_distribution_site_trait_coverage <- function(
   
   if (!is.null(species_categories)) {
     
-    category_name <- colnames(species_categories)[2]
+    category_name <- colnames(drop_column(species_categories, "species"))
     
     species_split <- split(
-      species_categories[, 1], species_categories[, 2]
+      species_categories[["species"]], 
+      drop_column(species_categories, "species", drop = TRUE)
     )
     
   }

--- a/R/fb_plot_site_traits_completeness.R
+++ b/R/fb_plot_site_traits_completeness.R
@@ -35,10 +35,11 @@ fb_plot_site_traits_completeness <- function(
   
   if (!is.null(species_categories)) {
     
-    category_name <- colnames(species_categories)[2]
+    category_name <- colnames(drop_column(species_categories, "species"))
     
     species_split <- split(
-      species_categories[, 1], species_categories[, 2]
+      species_categories[["species"]], 
+      drop_column(species_categories, "species", drop = TRUE)
     )
     
   }

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -44,7 +44,8 @@ fb_plot_species_traits_completeness <- function(
     
     species_traits_long_categories <- merge(
       species_traits_long, species_categories,
-      by.x = "species", by.y = colnames(species_categories)[1]
+      by.x = "species", 
+      by.y = colnames(drop_column(species_categories, "species"))
     )
     
   }
@@ -60,7 +61,7 @@ fb_plot_species_traits_completeness <- function(
     species_traits_categories, fb_count_traits_by_species
   )
   
-  n_max_trait <- ncol(species_traits[, -1, drop = FALSE])
+  n_max_trait <- ncol(species_traits) - 1
   
   # Get number of species with maximum known trait (per category)
   all_traits_list <- lapply(

--- a/R/fb_plot_species_traits_completeness.R
+++ b/R/fb_plot_species_traits_completeness.R
@@ -44,8 +44,7 @@ fb_plot_species_traits_completeness <- function(
     
     species_traits_long_categories <- merge(
       species_traits_long, species_categories,
-      by.x = "species", 
-      by.y = colnames(drop_column(species_categories, "species"))
+      by = "species"
     )
     
   }

--- a/R/fb_plot_species_traits_missingness.R
+++ b/R/fb_plot_species_traits_missingness.R
@@ -45,7 +45,7 @@ fb_plot_species_traits_missingness <- function(
     
     species_traits_long_categories <- merge(
       species_traits_long, species_categories,
-      by.x = "species", by.y = colnames(species_categories)[1]
+      by = "species"
     )
     
   }
@@ -70,7 +70,7 @@ fb_plot_species_traits_missingness <- function(
     species_traits_categories, fb_count_traits_by_species
   )
   
-  n_max_trait <- ncol(species_traits[, -1, drop = FALSE])
+  n_max_trait <- ncol(species_traits) - 1
   
   # Get number of species with maximum known trait (per category)
   all_traits_list <- lapply(

--- a/R/fb_plot_trait_correlation.R
+++ b/R/fb_plot_trait_correlation.R
@@ -48,7 +48,8 @@ fb_plot_trait_correlation <- function(
   
   trait_subset <- species_traits[
     , c(
-      colnames(species_traits)[1], colnames(species_traits)[-1][numerical_traits]
+      "species", 
+      colnames(drop_column(species_traits, "species"))[numerical_traits]
     ), drop = FALSE
   ]
   

--- a/R/fb_table_trait_summary.R
+++ b/R/fb_table_trait_summary.R
@@ -45,7 +45,7 @@ fb_table_trait_summary <- function(species_traits, kable = FALSE) {
   
   # Type
   trait_type <- lapply(
-    species_traits[, -1, drop = FALSE], function(x) class(x)[1]
+    drop_column(species_traits, "species"), function(x) class(x)[1]
   )
   
   trait_type <- vapply(
@@ -59,7 +59,7 @@ fb_table_trait_summary <- function(species_traits, kable = FALSE) {
   
   # Number Non-missing
   non_missing_number <- vapply(
-    species_traits[, -1, drop = FALSE], function(x) {
+    drop_column(species_traits, "species"), function(x) {
       sum(!is.na(x))
     },
     numeric(1)
@@ -67,7 +67,7 @@ fb_table_trait_summary <- function(species_traits, kable = FALSE) {
   
   # Proportion Non-missing
   prop_non_missing <- paste0(
-    round(non_missing_number/nrow(species_traits), 2) * 100, " %"
+    round(non_missing_number / nrow(species_traits), 2) * 100, " %"
   )
   
   # (Numerical traits) range
@@ -163,7 +163,7 @@ fb_table_trait_summary <- function(species_traits, kable = FALSE) {
   # Assemble Summary Table -----------------------------------------------------
   
   trait_summary_table <- data.frame(
-    trait_name             = colnames(species_traits[, -1, drop = FALSE]),
+    trait_name             = colnames(drop_column(species_traits, "species")),
     trait_type             = trait_type,
     number_non_missing     = non_missing_number,
     proportion_non_missing = prop_non_missing,

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,7 +26,7 @@ split_species_categories <- function(
   if (!is.null(species_categories)) {
     
     species_traits_categories <- merge(
-      species_traits, species_categories, by = colnames(species_categories)[1]
+      species_traits, species_categories, by = "species"
     )
     
     species_traits_categories <- split(
@@ -40,4 +40,14 @@ split_species_categories <- function(
   
   return(species_traits_categories)
   
+}
+
+#' Function to remove a column in a data.frame (e.g. 'site' or 'species') 
+#' without its position.
+#' 
+#' @noRd
+
+drop_column <- function(data, col_name, drop = FALSE) {
+
+  data[ , -which(colnames(data) == col_name), drop = drop]
 }

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -224,6 +224,12 @@ test_that("check_site_locations() works", {
     fixed = TRUE
   )
   
+  expect_error(
+    check_site_locations(sites_sf[,-1]),
+    "The site x locations object must contain the 'site' column",
+    fixed = TRUE
+  )
+  
   expect_silent(check_site_locations(sites_sf))
   
   expect_equal(check_site_locations(sites_sf), NULL)

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -236,6 +236,52 @@ test_that("check_site_locations() works", {
 })
 
 
+# Tests for check species-categories -------------------------------------------
+
+test_that("", {
+  
+  ## Wrong inputs
+  # Not good type of object
+  expect_error(
+    check_species_categories("a"),
+    "The species x categories object must be a data.frame",
+    fixed = TRUE
+  )
+  
+  # Not enough rows
+  expect_error(
+    check_species_categories(data.frame("a")[-1,, drop = FALSE]),
+    "The species x categories object should have at least one row",
+    fixed = TRUE
+  )
+  
+  # Not enough columns
+  expect_error(
+    check_species_categories(data.frame("a")),
+    paste0(
+      "The species x categories object must have two columns (species ", 
+      "name and one category)"
+    ),
+    fixed = TRUE
+  )
+  
+  # Not well named columns
+  expect_error(
+    check_species_categories(data.frame("a", "b")),
+    "The species x categories object must contain the 'species' column",
+    fixed = TRUE
+  )
+  
+  ## Working input
+  expect_silent(
+    check_species_categories(data.frame(species = "a", category = "plant"))
+  )
+  
+})
+
+
+# Tests for check threshold proportion -----------------------------------------
+
 test_that("check_threshold_proportion() works", {
   
   ## Wrong inputs

--- a/tests/testthat/test-fb_plot_number_species_by_trait.R
+++ b/tests/testthat/test-fb_plot_number_species_by_trait.R
@@ -65,7 +65,7 @@ test_that("fb_plot_number_species_by_trait() fails gracefully", {
   
   expect_error(
     fb_plot_number_species_by_trait(species_traits, FALSE),
-    "'species_categories' isn't a two-column data.frame"
+    "The species x categories object must be a data.frame"
   )
   
 })

--- a/tests/testthat/test-fb_plot_number_traits_by_species.R
+++ b/tests/testthat/test-fb_plot_number_traits_by_species.R
@@ -67,7 +67,7 @@ test_that("fb_plot_number_traits_by_species() fails gracefully", {
   
   expect_error(
     fb_plot_number_traits_by_species(species_traits, FALSE),
-    "'species_categories' isn't a two-column data.frame"
+    "The species x categories object must be a data.frame"
   )
   
 })

--- a/tests/testthat/test-fb_plot_species_traits_completeness.R
+++ b/tests/testthat/test-fb_plot_species_traits_completeness.R
@@ -76,7 +76,7 @@ test_that("fb_plot_species_traits_completeness() fails gracefully", {
   
   expect_error(
     fb_plot_species_traits_completeness(species_traits, FALSE),
-    "'species_categories' isn't a two-column data.frame"
+    "The species x categories object must be a data.frame"
   )
   
 })

--- a/tests/testthat/test-fb_plot_species_traits_missingness.R
+++ b/tests/testthat/test-fb_plot_species_traits_missingness.R
@@ -76,7 +76,7 @@ test_that("fb_plot_species_traits_missingness() fails gracefully", {
   
   expect_error(
     fb_plot_species_traits_missingness(species_traits, FALSE),
-    "'species_categories' isn't a two-column data.frame"
+    "The species x categories object must be a data.frame"
   )
   
 })


### PR DESCRIPTION
This PR is linked to #107 

Now we handle the `species` and `site` columns by their names and no more by their position (first column). Checks were already implemented except for `check_species_categories()` (it is done now).

To do this I've implemented a new function to remove one column:

```r
drop_column <- function(data, col_name, drop = FALSE) {
  data[ , -which(colnames(data) == col_name), drop = drop]
}
```