### PR TITLE
Update vdiffr snapshots to fix path errors

### DIFF
--- a/tests/testthat/_snaps/fb_plot_species_traits_missingness/fb-plot-sp-tr-miss-singletrait.svg
+++ b/tests/testthat/_snaps/fb_plot_species_traits_missingness/fb-plot-sp-tr-miss-singletrait.svg
@@ -66,6 +66,6 @@
 <rect x='416.65' y='28.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <text x='395.29' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='15.17px' lengthAdjust='spacingAndGlyphs'>Yes</text>
 <text x='438.70' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='11.25px' lengthAdjust='spacingAndGlyphs'>No</text>
-<text x='37.67' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='268.58px' lengthAdjust='spacingAndGlyphs'>fb_plot_species_traits_missingness-singletrait</text>
+<text x='37.67' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='171.70px' lengthAdjust='spacingAndGlyphs'>fb_plot_sp_tr_miss-singletrait</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-complete.svg
+++ b/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-complete.svg
@@ -43,14 +43,14 @@
 <rect x='80.98' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='397.75' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
-<rect x='556.14' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
+<rect x='556.14' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='80.98' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
-<rect x='397.75' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
-<rect x='556.14' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
+<rect x='397.75' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
+<rect x='556.14' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <rect x='80.98' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
-<rect x='397.75' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
+<rect x='397.75' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <rect x='556.14' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <rect x='80.98' y='61.98' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='61.98' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
@@ -60,9 +60,9 @@
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='76.05' y='490.76' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='57.97px' lengthAdjust='spacingAndGlyphs'>n = 14 (58.3%)</text>
-<text x='76.05' y='396.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 4 (16.7%)</text>
-<text x='76.05' y='301.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 3 (12.5%)</text>
-<text x='76.05' y='206.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 2 (8.3%)</text>
+<text x='76.05' y='396.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 3 (12.5%)</text>
+<text x='76.05' y='301.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 2 (8.3%)</text>
+<text x='76.05' y='206.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 4 (16.7%)</text>
 <text x='76.05' y='112.31' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 1 (4.2%)</text>
 <polyline points='78.24,487.73 80.98,487.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='78.24,393.12 80.98,393.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -87,6 +87,6 @@
 <rect x='414.12' y='28.40' width='17.00' height='17.00' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <text x='378.66' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>Missing</text>
 <text x='436.74' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='30.33px' lengthAdjust='spacingAndGlyphs'>Present</text>
-<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='267.13px' lengthAdjust='spacingAndGlyphs'>fb_plot_trait_combination_frequencies-default</text>
+<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='182.72px' lengthAdjust='spacingAndGlyphs'>fb_plot_tr_comb_freq-complete</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-default.svg
+++ b/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-default.svg
@@ -43,14 +43,14 @@
 <rect x='80.98' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='397.75' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
-<rect x='556.14' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
+<rect x='556.14' y='345.82' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <rect x='80.98' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
-<rect x='397.75' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
-<rect x='556.14' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
+<rect x='397.75' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
+<rect x='556.14' y='251.20' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='80.98' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
-<rect x='397.75' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
+<rect x='397.75' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='556.14' y='156.59' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
 <rect x='80.98' y='61.98' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <rect x='239.36' y='61.98' width='158.39' height='94.61' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E41A1C;' />
@@ -60,9 +60,9 @@
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='76.05' y='490.76' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='57.97px' lengthAdjust='spacingAndGlyphs'>n = 14 (58.3%)</text>
-<text x='76.05' y='396.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 3 (12.5%)</text>
-<text x='76.05' y='301.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 2 (8.3%)</text>
-<text x='76.05' y='206.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 4 (16.7%)</text>
+<text x='76.05' y='396.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 4 (16.7%)</text>
+<text x='76.05' y='301.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='53.08px' lengthAdjust='spacingAndGlyphs'>n = 3 (12.5%)</text>
+<text x='76.05' y='206.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 2 (8.3%)</text>
 <text x='76.05' y='112.31' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='48.19px' lengthAdjust='spacingAndGlyphs'>n = 1 (4.2%)</text>
 <polyline points='78.24,487.73 80.98,487.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='78.24,393.12 80.98,393.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -87,6 +87,6 @@
 <rect x='414.12' y='28.40' width='17.00' height='17.00' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <text x='378.66' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>Missing</text>
 <text x='436.74' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='30.33px' lengthAdjust='spacingAndGlyphs'>Present</text>
-<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='281.06px' lengthAdjust='spacingAndGlyphs'>fb_plot_trait_combination_frequencies-complete</text>
+<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='168.78px' lengthAdjust='spacingAndGlyphs'>fb_plot_tr_comb_freq-default</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-onecat.svg
+++ b/tests/testthat/_snaps/fb_plot_trait_combination_frequencies/fb-plot-tr-comb-freq-onecat.svg
@@ -98,6 +98,6 @@
 <rect x='414.12' y='28.40' width='17.00' height='17.00' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #377EB8;' />
 <text x='378.66' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>Missing</text>
 <text x='436.74' y='39.93' style='font-size: 8.80px; font-family: sans;' textLength='30.33px' lengthAdjust='spacingAndGlyphs'>Present</text>
-<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='267.13px' lengthAdjust='spacingAndGlyphs'>fb_plot_trait_combination_frequencies-onecat</text>
+<text x='80.98' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='168.79px' lengthAdjust='spacingAndGlyphs'>fb_plot_tr_comb_freq-onecat</text>
 </g>
 </svg>

--- a/tests/testthat/test-fb_plot_species_traits_missingness.R
+++ b/tests/testthat/test-fb_plot_species_traits_missingness.R
@@ -64,7 +64,7 @@ test_that("fb_plot_species_traits_missingness works", {
   expect_s3_class(given_plot, "ggplot")
   
   vdiffr::expect_doppelganger(
-    "fb_plot_species_traits_missingness-singletrait", 
+    "fb_plot_sp_tr_miss-singletrait", 
     given_plot
   )
   

--- a/tests/testthat/test-fb_plot_trait_combination_frequencies.R
+++ b/tests/testthat/test-fb_plot_trait_combination_frequencies.R
@@ -10,7 +10,7 @@ test_that("fb_plot_trait_combination_frequencies() works", {
   expect_s3_class(given_plot, "ggplot")
   
   vdiffr::expect_doppelganger(
-    "fb_plot_trait_combination_frequencies-default", 
+    "fb_plot_tr_comb_freq-default", 
     given_plot
   )
   
@@ -23,7 +23,7 @@ test_that("fb_plot_trait_combination_frequencies() works", {
   expect_s3_class(given_plot, "ggplot")
   
   vdiffr::expect_doppelganger(
-    "fb_plot_trait_combination_frequencies-complete", 
+    "fb_plot_tr_comb_freq-complete", 
     given_plot
   )
   
@@ -41,7 +41,7 @@ test_that("fb_plot_trait_combination_frequencies() works", {
   expect_s3_class(given_plot, "ggplot")
   
   vdiffr::expect_doppelganger(
-    "fb_plot_trait_combination_frequencies-onecat", 
+    "fb_plot_tr_comb_freq-onecat", 
     given_plot
   )
   


### PR DESCRIPTION
Try to fix long path names that cause errors in R CMD CHECK

By the way @ahasverus, why are many vdiffr blocks commented out in the tests?
Is it to make them shorter?

I haven't realized it when merging the vdiffr branch.