### PR TITLE
Better check the species x category object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     utils,
     xfun
 Suggests:
+    dplyr,
     fs,
     fundiversity,
     ggridges,

--- a/R/fb_plot_distribution_site_trait_coverage.R
+++ b/R/fb_plot_distribution_site_trait_coverage.R
@@ -76,7 +76,7 @@ fb_plot_distribution_site_trait_coverage <- function(
     function(single_category) {
       site_avg_coverage <- by(
       single_category, list(coverage_name = single_category[["coverage_name"]]),
-      \(y) mean(y$coverage_value, na.rm = TRUE)
+      function(y) mean(y$coverage_value, na.rm = TRUE)
     )
       site_avg_coverage <- utils::stack(site_avg_coverage)
       colnames(site_avg_coverage) <- c("avg_coverage", "coverage_name")
@@ -103,7 +103,7 @@ fb_plot_distribution_site_trait_coverage <- function(
   # Get order of coverage overall
   grand_avg_coverage <- utils::stack(
     by(avg_coverage, avg_coverage$coverage_name,
-       \(x) mean(x$avg_coverage, na.rm =TRUE))
+       function(x) mean(x$avg_coverage, na.rm =TRUE))
   )
   
   # Order coverage categories per decreasing coverage

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,10 +31,8 @@ split_species_categories <- function(
 
     if (nrow(species_traits_categories) == 0) {
       stop(
-        paste0(
           "No species of 'species x traits' object found in the ", 
-          "'species x categories' object"
-        ),
+          "'species x categories' object",
         call. = FALSE
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,6 +28,16 @@ split_species_categories <- function(
     species_traits_categories <- merge(
       species_traits, species_categories, by = "species"
     )
+
+    if (nrow(species_traits_categories) == 0) {
+      stop(
+        paste0(
+          "No species of 'species x traits' object found in the ", 
+          "'species x categories' object"
+        ),
+        call. = FALSE
+      )
+    }
     
     species_traits_categories <- split(
       species_traits_categories[

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -34,3 +34,48 @@ test_that("weighted_mean() works", {
   expect_equal(weighted_mean(c(2000, 1), c(NA,  1), na.rm = TRUE),  1)
   expect_equal(weighted_mean(c(NA, 1),  c(1e2,  1),  na.rm = TRUE),  1)
 })
+
+
+test_that("split_species_categories() works", {
+
+  sp_tr <- data.frame(
+    species = c("A", "B", "C"),
+    trait = 1:3
+  )
+
+  sp_cat_good <- data.frame(
+    species = c("A", "B", "F"),
+    order = c("AAA", "CCC", "BBB")
+  )
+
+  sp_cat_wrong <- data.frame(
+    species = c("D", "E", "F"),
+    order = c("AAA", "AAA", "BBB")
+  )
+  
+  # No species x categories
+  expect_silent(res <- split_species_categories(sp_tr))
+  expect_true(inherits(res, "list"))
+  expect_equal(length(res), 1L)
+  expect_equal(nrow(res[[1]]), 3L)
+  expect_equal(ncol(res[[1]]), 2L)
+
+  # With species x categories & species in common
+  expect_silent(res <- split_species_categories(sp_tr, sp_cat_good))
+  expect_true(inherits(res, "list"))
+  expect_equal(length(res), 2L)
+  expect_true("AAA" %in% names(res))
+  expect_true("CCC" %in% names(res))
+  expect_equal(nrow(res[[1]]), 1L)
+  expect_equal(ncol(res[[1]]), 2L)
+  expect_equal(nrow(res[[2]]), 1L)
+  expect_equal(ncol(res[[2]]), 2L)
+
+  expect_error(
+    split_species_categories(sp_tr, sp_cat_wrong),
+    paste0(
+      "No species of 'species x traits' object found in the ", 
+      "'species x categories' object"
+    )
+  )
+})


### PR DESCRIPTION
This PR fixes #85 by:
- adding a check in the function `split_species_categories()` that returns an error if no species in species x traits are found in species x categories.
- implementing unit tests for this function

Additionnally, this PR:
- adds `dplyr` in the Suggests field of the `DESCRIPTION` file
- removes anonymous functions in `fb_plot_distribution_site_trait_coverage()` to allow `funbiogeo` to work w/ older versions of R (3.5.0 instead of 4.1.0)