### PR TITLE
Documentation: improve cross-references and links

### DIFF
--- a/R/fb_aggregate_site_data.R
+++ b/R/fb_aggregate_site_data.R
@@ -33,6 +33,10 @@
 #'   layers (if `SpatRaster`) or columns (if `sf`) as columns provided in the
 #'   input `site_data`.
 #'
+#' @seealso the dedicated vignette on [aggregating site data](
+#' https://frbcesab.github.io/funbiogeo/articles/upscaling.html)
+#' for more details and examples.
+#' 
 #' @import sf
 #' @export
 #'

--- a/R/fb_count_sites_by_species.R
+++ b/R/fb_count_sites_by_species.R
@@ -11,6 +11,8 @@
 #' - `n_sites`: the number of sites where the species is present;
 #' - `coverage`: the percentage of sites where the species is present.
 #'
+#' @family {count functions}
+#' 
 #' @export
 #'
 #' @examples

--- a/R/fb_count_species_by_site.R
+++ b/R/fb_count_species_by_site.R
@@ -11,7 +11,9 @@
 #' - `site`: the name of the site;
 #' - `n_species`: the number of present species;
 #' - `coverage`: the percentage of present species.
-#'
+#' 
+#' @family {count functions}
+#' 
 #' @export
 #'
 #' @examples

--- a/R/fb_count_species_by_trait.R
+++ b/R/fb_count_species_by_trait.R
@@ -11,6 +11,8 @@
 #' - `n_species`: the number of species with non-missing value for the trait;
 #' - `coverage`: the percentage of species with non-missing value for the trait.
 #'
+#' @family {count functions}
+#' 
 #' @export
 #'
 #' @examples

--- a/R/fb_count_traits_by_species.R
+++ b/R/fb_count_traits_by_species.R
@@ -12,6 +12,8 @@
 #' - `coverage`: the percentage of traits with non-missing value for the
 #' species.
 #'
+#' @family {count functions}
+#' 
 #' @export
 #'
 #' @examples

--- a/R/fb_filter_sites_by_trait_coverage.R
+++ b/R/fb_filter_sites_by_trait_coverage.R
@@ -14,7 +14,15 @@
 #'
 #' @return A subset of `site_species` with sites covered by X% of
 #' abundance/coverage considering all provided traits.
-#'
+#' 
+#' @seealso [fb_plot_distribution_site_trait_coverage()] to visualize trait
+#' coverage by site, [fb_filter_species_by_trait_coverage()] to filter species
+#' by trait coverage, [fb_get_trait_coverage_by_site()] to compute trait
+#' coverage by site, [fb_get_all_trait_coverages_by_site()] to compute trait
+#' coverage for all traits taken altogether, and
+#' [fb_filter_sites_by_species_coverage()] for filtering sites by species
+#' coverage.
+#' 
 #' @export
 #'
 #' @examples

--- a/man/fb_aggregate_site_data.Rd
+++ b/man/fb_aggregate_site_data.Rd
@@ -67,3 +67,7 @@ fb_aggregate_site_data(
     fun = sum
 )
 }
+\seealso{
+the dedicated vignette on \href{https://frbcesab.github.io/funbiogeo/articles/upscaling.html}{aggregating site data}
+for more details and examples.
+}

--- a/man/fb_count_sites_by_species.Rd
+++ b/man/fb_count_sites_by_species.Rd
@@ -27,3 +27,10 @@ species (distribution value higher than 0 and non-NA).
 site_coverage_by_species <- fb_count_sites_by_species(woodiv_site_species)
 head(site_coverage_by_species)
 }
+\seealso{
+Other {count functions}:
+\code{\link[=fb_count_species_by_site]{fb_count_species_by_site()}},
+\code{\link[=fb_count_species_by_trait]{fb_count_species_by_trait()}},
+\code{\link[=fb_count_traits_by_species]{fb_count_traits_by_species()}}
+}
+\concept{{count functions}}

--- a/man/fb_count_species_by_site.Rd
+++ b/man/fb_count_species_by_site.Rd
@@ -28,3 +28,10 @@ provided. For example, a site could contain only 20\% of all species provided.
 species_coverage_by_site <- fb_count_species_by_site(woodiv_site_species)
 head(species_coverage_by_site)
 }
+\seealso{
+Other {count functions}:
+\code{\link[=fb_count_sites_by_species]{fb_count_sites_by_species()}},
+\code{\link[=fb_count_species_by_trait]{fb_count_species_by_trait()}},
+\code{\link[=fb_count_traits_by_species]{fb_count_traits_by_species()}}
+}
+\concept{{count functions}}

--- a/man/fb_count_species_by_trait.Rd
+++ b/man/fb_count_species_by_trait.Rd
@@ -28,3 +28,10 @@ without missing trait value (\code{NA}).
 species_coverage_by_trait <- fb_count_species_by_trait(woodiv_traits)
 head(species_coverage_by_trait)
 }
+\seealso{
+Other {count functions}:
+\code{\link[=fb_count_sites_by_species]{fb_count_sites_by_species()}},
+\code{\link[=fb_count_species_by_site]{fb_count_species_by_site()}},
+\code{\link[=fb_count_traits_by_species]{fb_count_traits_by_species()}}
+}
+\concept{{count functions}}

--- a/man/fb_count_traits_by_species.Rd
+++ b/man/fb_count_traits_by_species.Rd
@@ -29,3 +29,10 @@ without \code{NA} (missing trait values).
 trait_coverage_by_species <- fb_count_traits_by_species(woodiv_traits)
 head(trait_coverage_by_species)
 }
+\seealso{
+Other {count functions}:
+\code{\link[=fb_count_sites_by_species]{fb_count_sites_by_species()}},
+\code{\link[=fb_count_species_by_site]{fb_count_species_by_site()}},
+\code{\link[=fb_count_species_by_trait]{fb_count_species_by_trait()}}
+}
+\concept{{count functions}}

--- a/man/fb_filter_sites_by_trait_coverage.Rd
+++ b/man/fb_filter_sites_by_trait_coverage.Rd
@@ -51,3 +51,12 @@ new_site_species_2 <- fb_filter_sites_by_trait_coverage(
 # There are now four sites
 nrow(new_site_species_2)
 }
+\seealso{
+\code{\link[=fb_plot_distribution_site_trait_coverage]{fb_plot_distribution_site_trait_coverage()}} to visualize trait
+coverage by site, \code{\link[=fb_filter_species_by_trait_coverage]{fb_filter_species_by_trait_coverage()}} to filter species
+by trait coverage, \code{\link[=fb_get_trait_coverage_by_site]{fb_get_trait_coverage_by_site()}} to compute trait
+coverage by site, \code{\link[=fb_get_all_trait_coverages_by_site]{fb_get_all_trait_coverages_by_site()}} to compute trait
+coverage for all traits taken altogether, and
+\code{\link[=fb_filter_sites_by_species_coverage]{fb_filter_sites_by_species_coverage()}} for filtering sites by species
+coverage.
+}


### PR DESCRIPTION
This PR aims to continue improving the documentation of `funbiogeo`.
This has been suggested through leveraging Copilot and asking for the five best documentation improvement:

> 1. Add `@seealso` cross-references between related functions
> 
> Almost no functions have `@seealso` sections. Functions like fb_filter_sites_by_trait_coverage() directly calls fb_get_trait_coverage_by_site() internally, but a user reading one would never know the other exists. Adding `@seealso` to link filtering → coverage → plotting chains would help users discover the full API without reading every page.
> 
> 2. Write a real package-level help page
> 
> R/funbiogeo-package.R is effectively empty — `@keywords` internal with no description. This is the page users land on with ?funbiogeo or package?funbiogeo. It should describe the three core data objects (site_species, species_traits, site_locations), the fb_ naming convention, and point to the introduction vignette. It's a natural entry point that currently offers nothing.
> 
> 3. Document what happens at the boundary cases in `@return`
> 
> Several return descriptions are vague about edge cases. For example, fb_filter_sites_by_trait_coverage() says it returns "a subset of site_species" but only a runtime message() signals when the result is an empty data frame with zero rows. The `@return` section should state this explicitly — readers shouldn't need to run the function to discover it.
> 
> 4. Explain the default parameter choices
> 
> threshold_traits_proportion = 1 means "only keep sites where 100% of species have traits," which is a very strict default that will often return an empty result (as the example itself demonstrates with nrow = 1). The `@param` description says it's "the percentage trait coverage threshold" but doesn't explain why 1 is the default or warn the user about its strictness. Parameters with non-obvious defaults deserve a sentence of rationale.
> 
> 5. Add a workflow summary section at the top of the introduction vignette
> 
> The introduction vignette dives directly into data type definitions. A short upfront section — even just a numbered list of the typical analysis steps with the function names involved — would dramatically help new users orient themselves before reading the details. The README has a function scheme diagram, but the vignette, which is where users spend most of their time, has no equivalent overview.

I think all of them are pretty sensible and I'll try to implement some of them in this PR.