### PR TITLE
Fix cran issues

### DIFF
--- a/R/fb_make_report.R
+++ b/R/fb_make_report.R
@@ -16,8 +16,7 @@
 #'
 #' @param path a `character` of length 1. The directory in which the `.Rmd` and
 #'   `.rds` files will be created. This directory must exist. Note that
-#'   subdirectories `funbiogeo/` and `funbiogeo/data/` will be created. Default
-#'   is the current directory.
+#'   subdirectories `funbiogeo/` and `funbiogeo/data/` will be created.
 #'
 #' @param filename a `character` of length 1. The name of the `.Rmd` file to be
 #'   created. If `NULL` (default) the `.Rmd` file will be named from the `title`
@@ -47,7 +46,7 @@
 #'
 #' @examples
 #' if (interactive()) {
-#' 
+#'
 #' # Create temporary folder (optional) ----
 #' temp_path <- tempdir()
 #'
@@ -72,7 +71,7 @@
 #' }
 
 fb_make_report <- function(
-  path = ".",
+  path,
   filename = NULL,
   title = NULL,
   author = NULL,
@@ -106,6 +105,22 @@ fb_make_report <- function(
   }
 
   # Check path -----------------------------------------------------------------
+
+  if (missing(path)) {
+    stop("Argument 'path' is required", call. = FALSE)
+  }
+
+  if (is.null(path)) {
+    stop("Argument 'path' is required", call. = FALSE)
+  }
+
+  if (!is.character(path)) {
+    stop("Argument 'path' must be a character", call. = FALSE)
+  }
+
+  if (length(path) != 1) {
+    stop("Argument 'path' must be of length one", call. = FALSE)
+  }
 
   if (!dir.exists(path)) {
     stop("The path '", path, "' does not exist", call. = FALSE)

--- a/R/fb_make_report.R
+++ b/R/fb_make_report.R
@@ -46,7 +46,8 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' if (interactive()) {
+#' 
 #' # Create temporary folder (optional) ----
 #' temp_path <- tempdir()
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
 ## Test environments
 
 * Local
-  * Fedora Linux 7.0.14-201.fc44.x86_64 (R 4.6.0)
+  * Fedora Linux 7.1.3-201.fc44.x86_64 (R 4.6.0)
   * Debian 13 Linux 6.12.74+deb13+1-amd64 (R 4.6.0)
   * Windows 11 26200 (R 4.4.2)
   
@@ -38,21 +38,19 @@ There are currently no downstream dependencies for this package.
 
 Hi,
 
-This resubmission fixes these two notes:
+This resubmission fixes:
 
-- Invalid URI
+- The `\dontrun{}` wrapper
 
-```
-Found the following (possibly) invalid file URI:
-  URI: vignettes/upscaling.Rmd
-    From: inst/doc/special_cases.html
-```
+Only the `fb_make_report()` function used this wrapper in the example section. 
+It has been replaced by `if (interactive()) {}` as this function requires an 
+interaction with the user.
 
-- Checktime > 10 min
+- Write by default in the current directory
 
-All vignettes have been removed from the build but are still available on the 
-package website. A new vignette is shipped with the package and provides links
-to the official documentation.
+The default value of the argument `path` (current directory) of the 
+`fb_make_report()` function has been removed. Now the user must provide a path
+otherwise the function will throw an error.
 
 
 Best,

--- a/man/fb_make_report.Rd
+++ b/man/fb_make_report.Rd
@@ -80,7 +80,8 @@ Note that a copy of user data will be saved as \code{.rds} files in
 \verb{path/funbiogeo/data/} (where \code{path} is the directory defined by the user).
 }
 \examples{
-\dontrun{
+if (interactive()) {
+
 # Create temporary folder (optional) ----
 temp_path <- tempdir()
 

--- a/man/fb_make_report.Rd
+++ b/man/fb_make_report.Rd
@@ -5,7 +5,7 @@
 \title{Create an Rmarkdown Report to Explore User Data}
 \usage{
 fb_make_report(
-  path = ".",
+  path,
   filename = NULL,
   title = NULL,
   author = NULL,
@@ -20,8 +20,7 @@ fb_make_report(
 \arguments{
 \item{path}{a \code{character} of length 1. The directory in which the \code{.Rmd} and
 \code{.rds} files will be created. This directory must exist. Note that
-subdirectories \verb{funbiogeo/} and \verb{funbiogeo/data/} will be created. Default
-is the current directory.}
+subdirectories \verb{funbiogeo/} and \verb{funbiogeo/data/} will be created.}
 
 \item{filename}{a \code{character} of length 1. The name of the \code{.Rmd} file to be
 created. If \code{NULL} (default) the \code{.Rmd} file will be named from the \code{title}

--- a/tests/testthat/test-fb_make_report.R
+++ b/tests/testthat/test-fb_make_report.R
@@ -65,6 +65,36 @@ test_that("fb_make_report() errors", {
     ask_user = function() "yes",
     {
       expect_error(
+        fb_make_report(),
+        "Argument 'path' is required",
+        fixed = TRUE
+      )
+
+      expect_error(
+        fb_make_report(NULL),
+        "Argument 'path' is required",
+        fixed = TRUE
+      )
+
+      expect_error(
+        fb_make_report(1L),
+        "Argument 'path' must be a character",
+        fixed = TRUE
+      )
+
+      expect_error(
+        fb_make_report(data.frame()),
+        "Argument 'path' must be a character",
+        fixed = TRUE
+      )
+
+      expect_error(
+        fb_make_report(letters[1:2]),
+        "Argument 'path' must be of length one",
+        fixed = TRUE
+      )
+
+      expect_error(
         fb_make_report(
           path = file.path(temp_dir, "reports")
         ),


### PR DESCRIPTION
This PR fixes:

- The `\dontrun{}` wrapper

Only the `fb_make_report()` function used this wrapper in the example section. 
It has been replaced by `if (interactive()) {}` as this function requires an 
interaction with the user.

- Write by default in the current directory

The default value of the argument `path` (current directory) of the 
`fb_make_report()` function has been removed. Now the user must provide a path
otherwise the function will throw an error.
